### PR TITLE
Fix error in GCC 10.2.1

### DIFF
--- a/source/Lib/DecoderLib/DecCu.cpp
+++ b/source/Lib/DecoderLib/DecCu.cpp
@@ -169,8 +169,8 @@ void DecCu::TaskDeriveDMVRMotionInfo( CodingStructure& cs, const UnitArea& ctuAr
       const int dy = std::min<int>( pu.lumaSize().height, DMVR_SUBCU_HEIGHT );
       const int dx = std::min<int>( pu.lumaSize().width,  DMVR_SUBCU_WIDTH );
       
-      static constexpr unsigned scale = 4 * std::max<int>(1, 4 * AMVP_DECIMATION_FACTOR / 4);
-      static constexpr unsigned mask  = scale - 1;
+      static const unsigned scale = 4 * std::max<int>(1, 4 * AMVP_DECIMATION_FACTOR / 4);
+      static const unsigned mask  = scale - 1;
 
       const Position puPos = pu.lumaPos();
       const Mv mv0 = pu.mv[0][0];


### PR DESCRIPTION
```
DecCu.cpp: In member function 'void DecCu::TaskDeriveDMVRMotionInfo(CodingStructure&, const UnitArea&)':
DecCu.cpp:172:92: error: call to non-'constexpr' function 'const _Tp& std::max(const _Tp&, const _Tp&) [with _Tp = int]'
  172 |       static constexpr unsigned scale = 4 * std::max<int>(1, 4 * AMVP_DECIMATION_FACTOR / 4);
      |                                                                                            ^
In file included from c:\msys1021\include\c++\10.2.1\algorithm:61,
                 from c:\msys1021\x86_64-w64-mingw32\include\commonlib\CommonDef.h:54,
                 from c:\msys1021\x86_64-w64-mingw32\include\commonlib\contexts.h:54,
                 from BinDecoder.h:54,
                 from CABACReader.h:54,
                 from DecCu.h:58,
                 from DecCu.cpp:51:
c:\msys1021\include\c++\10.2.1\bits\stl_algobase.h:254:5: note: 'const _Tp& std::max(const _Tp&, const _Tp&) [with _Tp = int]' declared here
  254 |     max(const _Tp& __a, const _Tp& __b)
      |     ^~~
```