### PR TITLE
fix bug when enabled feature conformanceWindow (CROP_B_Panasonic_*)

### DIFF
--- a/source/Lib/CommonLib/Slice.h
+++ b/source/Lib/CommonLib/Slice.h
@@ -1473,6 +1473,7 @@ private:
   unsigned          m_dualITree                          = 0;
   uint32_t          m_uiMaxCUWidth                       = 32;
   uint32_t          m_uiMaxCUHeight                      = 32;
+  bool              m_conformanceWindowPresentFlag       = false;
   Window            m_conformanceWindow;
   bool              m_independentSubPicsFlag             = false;
 #if JVET_S0071_SAME_SIZE_SUBPIC_LAYOUT
@@ -1656,6 +1657,8 @@ public:
   uint32_t                getMaxPicWidthInLumaSamples() const                                             { return  m_maxWidthInLumaSamples; }
   void                    setMaxPicHeightInLumaSamples( uint32_t u )                                      { m_maxHeightInLumaSamples = u; }
   uint32_t                getMaxPicHeightInLumaSamples() const                                            { return  m_maxHeightInLumaSamples; }
+  void                    setConformanceWindowPresentFlag(bool b)                                         { m_conformanceWindowPresentFlag = b;           }
+  bool                    getConformanceWindowPresentFlag() const                                         { return m_conformanceWindowPresentFlag;        }
   Window&                 getConformanceWindow()                                                          { return  m_conformanceWindow;                                         }
   const Window&           getConformanceWindow() const                                                    { return  m_conformanceWindow;                                         }
   void                    setConformanceWindow(Window& conformanceWindow )                                { m_conformanceWindow = conformanceWindow;                             }
@@ -2204,6 +2207,7 @@ private:
   ScalingList      m_scalingList;                       //!< ScalingList class
   uint32_t         m_picWidthInLumaSamples;
   uint32_t         m_picHeightInLumaSamples;
+  bool             m_conformanceWindowPresentFlag        = false;
   Window           m_conformanceWindow;
   Window           m_scalingWindow;
   PPSRExt          m_ppsRangeExtension;
@@ -2477,6 +2481,8 @@ public:
   void                    setPicHeightInLumaSamples( uint32_t u )                         { m_picHeightInLumaSamples = u; }
   uint32_t                getPicHeightInLumaSamples() const                               { return  m_picHeightInLumaSamples; }
 
+  void                    setConformanceWindowPresentFlag(bool b)                         { m_conformanceWindowPresentFlag = b;           }
+  bool                    getConformanceWindowPresentFlag() const                         { return m_conformanceWindowPresentFlag;        }
   Window&                 getConformanceWindow()                                          { return  m_conformanceWindow; }
   const Window&           getConformanceWindow() const                                    { return  m_conformanceWindow; }
   void                    setConformanceWindow( Window& conformanceWindow )               { m_conformanceWindow = conformanceWindow; }

--- a/source/Lib/DecoderLib/VLCReader.cpp
+++ b/source/Lib/DecoderLib/VLCReader.cpp
@@ -373,7 +373,7 @@ void HLSyntaxReader::parsePPS( PPS* pcPPS, ParameterSetManager *parameterSetMana
   READ_UVLC( uiCode, "pps_pic_width_in_luma_samples" );                      pcPPS->setPicWidthInLumaSamples( uiCode );
   READ_UVLC( uiCode, "pps_pic_height_in_luma_samples" );                     pcPPS->setPicHeightInLumaSamples( uiCode );
 
-  READ_FLAG( uiCode, "pps_conformance_window_flag" );
+  READ_FLAG(uiCode, "pps_conformance_window_flag");                          pcPPS->setConformanceWindowPresentFlag( uiCode );
   if( uiCode != 0 )
   {
     Window &conf = pcPPS->getConformanceWindow();
@@ -1293,7 +1293,7 @@ void HLSyntaxReader::parseSPS( SPS* pcSPS, ParameterSetManager *parameterSetMana
   READ_UVLC( uiCode, "sps_pic_width_max_in_luma_samples" );                  pcSPS->setMaxPicWidthInLumaSamples( uiCode );
   READ_UVLC( uiCode, "sps_pic_height_max_in_luma_samples" );                 pcSPS->setMaxPicHeightInLumaSamples( uiCode );
 
-  READ_FLAG( uiCode, "sps_conformance_window_flag" );
+  READ_FLAG( uiCode, "sps_conformance_window_flag" );                        pcSPS->setConformanceWindowPresentFlag( uiCode );
   if( uiCode != 0 )
   {
     Window& conf = pcSPS->getConformanceWindow();

--- a/source/Lib/vvdec/vvdecimpl.cpp
+++ b/source/Lib/vvdec/vvdecimpl.cpp
@@ -785,17 +785,19 @@ int VVDecImpl::copyComp( const unsigned char* pucSrc, unsigned char* pucDest, un
 
 int VVDecImpl::xAddPicture( Picture* pcPic )
 {
-  // copy internal picture to external
-  const Window &conf    = pcPic->cs->pps->getConformanceWindow();
+  // copy internal picture to external (Priority PPS > SPS)
+  const Window &conf    = pcPic->cs->pps->getConformanceWindowPresentFlag()
+                          ? pcPic->cs->pps->getConformanceWindow()
+                          : pcPic->cs->sps->getConformanceWindow();
 //          const Window  defDisp = (m_respectDefDispWindow && pcPic->cs->sps->getVuiParametersPresentFlag())
 //                                  ? pcPic->cs->sps->getVuiParameters()->getDefaultDisplayWindow()
 //                                  : Window();
   const Window  defDisp =  Window();
 
-  int confLeft   = conf.getWindowLeftOffset()   + defDisp.getWindowLeftOffset();
-  int confRight  = conf.getWindowRightOffset()  + defDisp.getWindowRightOffset();
-  int confTop    = conf.getWindowTopOffset()    + defDisp.getWindowTopOffset();
-  int confBottom = conf.getWindowBottomOffset() + defDisp.getWindowBottomOffset();
+  int confLeft   = conf.getWindowLeftOffset()   * SPS::getWinUnitY(pcPic->cs->sps->getChromaFormatIdc())  + defDisp.getWindowLeftOffset();
+  int confRight  = conf.getWindowRightOffset()  * SPS::getWinUnitY(pcPic->cs->sps->getChromaFormatIdc())  + defDisp.getWindowRightOffset();
+  int confTop    = conf.getWindowTopOffset()    * SPS::getWinUnitY(pcPic->cs->sps->getChromaFormatIdc())  + defDisp.getWindowTopOffset();
+  int confBottom = conf.getWindowBottomOffset() * SPS::getWinUnitY(pcPic->cs->sps->getChromaFormatIdc())  + defDisp.getWindowBottomOffset();
 
   const CPelUnitBuf& cPicBuf =  pcPic->getRecoBuf();
 
@@ -862,9 +864,9 @@ int VVDecImpl::xAddPicture( Picture* pcPic )
       const ptrdiff_t   planeOffset = (confLeft >> csx) + (confTop >> csy) * area.stride;
 
       //unsigned char* pucOrigin   = (unsigned char*)area.bufAt (0, 0).ptr;
-      unsigned char* pucOrigin   = (unsigned char*)area.buf;
+      Pel* pucOrigin   = (Pel*)area.buf;
 
-      cFrame.m_cComponent[comp].m_pucBuffer = pucOrigin + planeOffset;
+      cFrame.m_cComponent[comp].m_pucBuffer = (unsigned char*)(pucOrigin + planeOffset);
     }
     m_pcLibPictureList.push_back( pcPic );
   }


### PR DESCRIPTION
Current code can't output correct YUV file,  sequence CROP_A_Panasonic_3.bit and CROP_B_Panasonic_4.bit decode YUV md5 mismatch, I fixed it.
