### PR TITLE
[CHEN] Fix vvdec issue #17

### DIFF
--- a/source/Lib/DecoderLib/DecLibParser.cpp
+++ b/source/Lib/DecoderLib/DecLibParser.cpp
@@ -474,7 +474,7 @@ DecLibParser::SliceHeadResult DecLibParser::xDecodeSliceHead( InputNALUnit& nalu
   m_apcSlicePilot->setAssociatedIRAPType( m_associatedIRAPType );
 
   //For inference of NoOutputOfPriorPicsFlag
-  if( m_apcSlicePilot->getRapPicFlag() || m_apcSlicePilot->getNalUnitType() == NAL_UNIT_CODED_SLICE_GDR )
+  if( /*m_apcSlicePilot->getRapPicFlag() ||*/ m_apcSlicePilot->getNalUnitType() == NAL_UNIT_CODED_SLICE_GDR )
   {
     if( !pps->getMixedNaluTypesInPicFlag() )
     {


### PR DESCRIPTION
  * The checkNoOutputPriorPics() processing async, it make wrong DPB clear operators.
  * The check is better put in DecLib::decompressPicture()
  * There is no evidence in the spec that this operation must be do when a RAP picture is performed.
  * The spec also suggest set the flag m_apcSlicePilot->setNoOutputOfPriorPicsFlag equal to sh_no_output_of_prior_pics_flag.