### PR TITLE
[CHEN] Fix bug on LTRP_A_ERICSSON_3

### DIFF
--- a/source/Lib/CommonLib/Slice.h
+++ b/source/Lib/CommonLib/Slice.h
@@ -112,6 +112,7 @@ private:
 public:
   ReferencePictureList();
   void    setRefPicIdentifier( int idx, int identifier, bool isLongterm, bool isInterLayerRefPic, int interLayerIdx );
+  void    setRefPicIdentifier( int idx, int identifier ) { m_refPicIdentifier[idx] = identifier; }
   int     getRefPicIdentifier(int idx) const;
   bool    isRefPicLongterm(int idx) const;
 

--- a/source/Lib/DecoderLib/DecLibParser.cpp
+++ b/source/Lib/DecoderLib/DecLibParser.cpp
@@ -586,6 +586,35 @@ DecLibParser::SliceHeadResult DecLibParser::xDecodeSliceHead( InputNALUnit& nalu
 
   m_prevLayerID = nalu.m_nuhLayerId;
 
+  // Copy LongTerm Identifier flag to RPL item if it is uninitialized
+  if( m_apcSlicePilot->getRPL0()->getNumberOfLongtermPictures() > 0 )
+  {
+    auto rpl0       = const_cast<ReferencePictureList*>( m_apcSlicePilot->getRPL0() );
+    auto rpl0_local = m_apcSlicePilot->getLocalRPL0();
+
+    for( int ii = 0; ii < m_apcSlicePilot->getNumRefIdx( REF_PIC_LIST_0 ); ii++ )
+    {
+      if( rpl0->isRefPicLongterm( ii ) && !rpl0->getRefPicIdentifier( ii ) )
+      {
+        rpl0->setRefPicIdentifier( ii, rpl0_local->getRefPicIdentifier( ii ) );
+      }
+    }
+  }
+
+  if( m_apcSlicePilot->getRPL1()->getNumberOfLongtermPictures() > 0 )
+  {
+    auto rpl1       = const_cast<ReferencePictureList*>( m_apcSlicePilot->getRPL1() );
+    auto rpl1_local = m_apcSlicePilot->getLocalRPL1();
+
+    for( int ii = 0; ii < m_apcSlicePilot->getNumRefIdx( REF_PIC_LIST_1 ); ii++ )
+    {
+      if( rpl1->isRefPicLongterm( ii ) && !rpl1->getRefPicIdentifier( ii ) )
+      {
+        rpl1->setRefPicIdentifier( ii, rpl1_local->getRefPicIdentifier( ii ) );
+      }
+    }
+  }
+
   //detect lost reference picture and insert copy of earlier frame.
   {
     int lostPoc = MAX_INT;


### PR DESCRIPTION
  * RPL managed by two lists: RPL and LocalRPL
  * The long-term reference frame identifier is not always synchronized in the list
  * I copy these identifier fro LocalRPL to RPL if it is not initialized