### PR TITLE
Fix warning 'missing output picture' in WPP_B_Sharp_2

### DIFF
--- a/source/Lib/DecoderLib/DecLib.cpp
+++ b/source/Lib/DecoderLib/DecLib.cpp
@@ -197,19 +197,22 @@ Picture* DecLib::decode( InputNALUnit& nalu, int* pSkipFrame )
     this->decompressPicture( pcParsedPic );
   }
 
-  if(      pcParsedPic
-      ||   nalu.m_nalUnitType == NAL_UNIT_EOS
-      || ( nalu.m_nalUnitType >= NAL_UNIT_CODED_SLICE_TRAIL      && nalu.m_nalUnitType <= NAL_UNIT_RESERVED_IRAP_VCL_12 )
-      || ( nalu.m_nalUnitType >= NAL_UNIT_CODED_SLICE_IDR_W_RADL && nalu.m_nalUnitType <= NAL_UNIT_CODED_SLICE_GDR )
-    )
+  if( m_decLibParser.getParseNewPicture() )
   {
-    Picture* outPic = getNextOutputPic( false );
-    CHECK_WARN( m_checkMissingOutput && !outPic, "missing output picture" ); // we don't need this CHECK in flushPic(), because flushPic() is usually only called until the first nullptr is returned
-    if( outPic )
+    if(      pcParsedPic
+        ||   nalu.m_nalUnitType == NAL_UNIT_EOS
+        || ( nalu.m_nalUnitType >= NAL_UNIT_CODED_SLICE_TRAIL      && nalu.m_nalUnitType <= NAL_UNIT_RESERVED_IRAP_VCL_12 )
+        || ( nalu.m_nalUnitType >= NAL_UNIT_CODED_SLICE_IDR_W_RADL && nalu.m_nalUnitType <= NAL_UNIT_CODED_SLICE_GDR )
+      )
     {
-      m_checkMissingOutput = true;
+      Picture* outPic = getNextOutputPic( false );
+      CHECK_WARN( m_checkMissingOutput && !outPic, "missing output picture" ); // we don't need this CHECK in flushPic(), because flushPic() is usually only called until the first nullptr is returned
+      if( outPic )
+      {
+        m_checkMissingOutput = true;
+      }
+      return outPic;
     }
-    return outPic;
   }
 
   return nullptr;

--- a/source/Lib/DecoderLib/DecLibParser.cpp
+++ b/source/Lib/DecoderLib/DecLibParser.cpp
@@ -218,6 +218,8 @@ Picture* DecLibParser::parse( InputNALUnit& nalu, int* pSkipFrame )
   {
     const auto ret = xDecodeSliceHead( nalu, pSkipFrame );
 
+    m_parseNewPicture = ( ret == NewPicture );
+
     if( ret == NewPicture && m_parseFrameList.size() > m_parseFrameDelay )
     {
       Picture* pic = getNextDecodablePicture();

--- a/source/Lib/DecoderLib/DecLibParser.h
+++ b/source/Lib/DecoderLib/DecLibParser.h
@@ -83,6 +83,7 @@ private:
   bool m_bFirstSliceInPicture     = true;
   bool m_bFirstSliceInSequence[MAX_VPS_LAYERS] = { true };
   bool m_bFirstSliceInBitstream   = true;
+  bool m_parseNewPicture          = false;
 
   int  m_lastPOCNoOutputPriorPics = -1;
   bool m_isNoOutputPriorPics      = false;
@@ -166,6 +167,7 @@ public:
   void checkNoOutputPriorPics   ();
   void setNoOutputPriorPicsFlag (bool val)              { m_isNoOutputPriorPics = val; }
   bool getNoOutputPriorPicsFlag () const                { return m_isNoOutputPriorPics; }
+  bool getParseNewPicture       () const                { return m_parseNewPicture; }
 
   void setDecodedSEIMessageOutputStream( std::ostream* pOpStream ) { m_pDecodedSEIOutputStream = pOpStream; }
 


### PR DESCRIPTION
Some of test clips will report "missing output picture", such as WPP_B_Sharp_2.
It is multiple-slices feature flush output queue early as expected.
