### PR TITLE
Feature/dll

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -243,6 +243,7 @@ endif()
 
 add_subdirectory( "source/Lib/vvdec" )
 add_subdirectory( "source/App/vvdecapp" )
+add_subdirectory( "source/App/libvvcdec" )
 
 # create a list of all test bitstreams in variable BITSTREAM_FILES
 # also defines BITSTREAM_URL_BASE

--- a/source/App/libvvcdec/CMakeLists.txt
+++ b/source/App/libvvcdec/CMakeLists.txt
@@ -17,8 +17,7 @@ set_target_properties( ${DLL_NAME} PROPERTIES MINSIZEREL_POSTFIX     "${CMAKE_MI
 target_compile_options( ${DLL_NAME} PRIVATE $<$<OR:$<CXX_COMPILER_ID:Clang>,$<CXX_COMPILER_ID:AppleClang>>:-Wall -Werror>
                                             $<$<CXX_COMPILER_ID:GNU>:-Wall -Werror>
                                             $<$<CXX_COMPILER_ID:MSVC>:/W4 /WX /wd4244 /wd4456 >)
-#target_link_libraries( ${DLL_NAME} Threads::Threads vvdec )
-
+target_link_libraries( ${DLL_NAME} Threads::Threads vvdec )
 
 # example: place header files in different folders
 source_group( "Header Files"   FILES ${INC_FILES} )

--- a/source/App/libvvcdec/CMakeLists.txt
+++ b/source/App/libvvcdec/CMakeLists.txt
@@ -1,0 +1,27 @@
+# executable
+set( DLL_NAME libvvcdec )
+
+# get source files
+file( GLOB SRC_FILES "*.cpp" )
+
+# get include files
+file( GLOB INC_FILES "*.h" )
+
+# add executable
+add_library(${DLL_NAME} SHARED  ${SRC_FILES} ${INC_FILES})
+set_target_properties( ${DLL_NAME} PROPERTIES RELEASE_POSTFIX        "${CMAKE_RELEASE_POSTFIX}" )
+set_target_properties( ${DLL_NAME} PROPERTIES DEBUG_POSTFIX          "${CMAKE_DEBUG_POSTFIX}" )
+set_target_properties( ${DLL_NAME} PROPERTIES RELWITHDEBINFO_POSTFIX "${CMAKE_RELWITHDEBINFO_POSTFIX}" )
+set_target_properties( ${DLL_NAME} PROPERTIES MINSIZEREL_POSTFIX     "${CMAKE_MINSIZEREL_POSTFIX}" )
+
+target_compile_options( ${DLL_NAME} PRIVATE $<$<OR:$<CXX_COMPILER_ID:Clang>,$<CXX_COMPILER_ID:AppleClang>>:-Wall -Werror>
+                                            $<$<CXX_COMPILER_ID:GNU>:-Wall -Werror>
+                                            $<$<CXX_COMPILER_ID:MSVC>:/W4 /WX /wd4244 /wd4456 >)
+#target_link_libraries( ${DLL_NAME} Threads::Threads vvdec )
+
+
+# example: place header files in different folders
+source_group( "Header Files"   FILES ${INC_FILES} )
+
+# set the folder where to place the projects
+set_target_properties( ${DLL_NAME}  PROPERTIES FOLDER app )

--- a/source/App/libvvcdec/CMakeLists.txt
+++ b/source/App/libvvcdec/CMakeLists.txt
@@ -1,5 +1,5 @@
 # executable
-set( DLL_NAME libvvcdec )
+set( DLL_NAME vvcdec )
 
 # get source files
 file( GLOB SRC_FILES "*.cpp" )

--- a/source/App/libvvcdec/libvvcdec.cpp
+++ b/source/App/libvvcdec/libvvcdec.cpp
@@ -1,0 +1,195 @@
+/* -----------------------------------------------------------------------------
+The copyright in this software is being made available under the BSD
+License, included below. No patent rights, trademark rights and/or 
+other Intellectual Property Rights other than the copyrights concerning 
+the Software are granted under this license.
+
+For any license concerning other Intellectual Property rights than the software, 
+especially patent licenses, a separate Agreement needs to be closed. 
+For more information please contact:
+
+Fraunhofer Heinrich Hertz Institute
+Einsteinufer 37
+10587 Berlin, Germany
+www.hhi.fraunhofer.de/vvc
+vvc@hhi.fraunhofer.de
+
+Copyright (c) 2018-2020, Fraunhofer-Gesellschaft zur Förderung der angewandten Forschung e.V. 
+All rights reserved.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are met:
+
+ * Redistributions of source code must retain the above copyright notice,
+   this list of conditions and the following disclaimer.
+ * Redistributions in binary form must reproduce the above copyright notice,
+   this list of conditions and the following disclaimer in the documentation
+   and/or other materials provided with the distribution.
+ * Neither the name of Fraunhofer nor the names of its contributors may
+   be used to endorse or promote products derived from this software without
+   specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS
+BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+THE POSSIBILITY OF SUCH DAMAGE.
+
+
+------------------------------------------------------------------------------------------- */
+
+#include "libvvcdec.h"
+
+namespace
+{
+
+class vvcDecoderWrapper
+{
+public:
+  vvcDecoderWrapper()
+  {
+
+  }
+  ~vvcDecoderWrapper()
+  {
+    
+  }
+private:
+
+};
+
+}
+
+extern "C" {
+
+  VVCDECAPI const char *libvvcdec_get_version(void)
+  {
+    // TODO
+    return "";
+  }
+
+  VVCDECAPI libvvcdec_context* libvvcdec_new_decoder(void)
+  {
+    auto decCtx = new vvcDecoderWrapper();
+    if (!decCtx)
+      return nullptr;
+
+    return (libvvcdec_context*)decCtx;
+  }
+
+  VVCDECAPI libvvcdec_error libvvcdec_free_decoder(libvvcdec_context* decCtx)
+  {
+    auto d = (vvcDecoderWrapper*)decCtx;
+    if (!d)
+      return LIBVVCDEC_ERROR;
+
+    delete d;
+    return LIBVVCDEC_OK;
+  }
+
+  VVCDECAPI libvvcdec_error libvvcdec_push_nal_unit(libvvcdec_context *decCtx, const void* data8, int length, bool eof, bool &bNewPicture, bool &checkOutputPictures)
+  {
+    auto d = (vvcDecoderWrapper*)decCtx;
+    if (!d)
+      return LIBVVCDEC_ERROR;
+
+    // TODO
+    (void)data8;
+    (void)length;
+    (void)eof;
+    (void)bNewPicture;
+    (void)checkOutputPictures;
+
+    return LIBVVCDEC_OK;
+  }
+
+  VVCDECAPI libvvcdec_picture *libvvcdec_get_picture(libvvcdec_context* decCtx)
+  {
+    auto d = (vvcDecoderWrapper*)decCtx;
+    if (!d)
+      return nullptr;
+
+    // TODO
+    return nullptr;
+  }
+
+  VVCDECAPI int libHMDEC_get_POC(libvvcdec_picture *pic)
+  {
+    if (pic == nullptr)
+      return -1;
+    
+    // TODO
+    return 0;
+  }
+
+  VVCDECAPI int libHMDEC_get_picture_width(libvvcdec_picture *pic, libvvcdec_ColorComponent c)
+  {
+    if (pic == nullptr)
+      return -1;
+    
+    // TODO
+    (void)c;
+
+    return -1;
+  }
+
+  VVCDECAPI int libHMDEC_get_picture_height(libvvcdec_picture *pic, libvvcdec_ColorComponent c)
+  {
+    if (pic == nullptr)
+      return -1;
+    
+    // TODO
+    (void)c;
+
+    return -1;
+  }
+
+  VVCDECAPI int libHMDEC_get_picture_stride(libvvcdec_picture *pic, libvvcdec_ColorComponent c)
+  {
+    if (pic == nullptr)
+      return -1;
+    
+    // TODO
+    (void)c;
+
+    return -1;
+  }
+
+  VVCDECAPI short* libHMDEC_get_image_plane(libvvcdec_picture *pic, libvvcdec_ColorComponent c)
+  {
+    if (pic == nullptr)
+      return nullptr;
+    
+    // TODO
+    (void)c;
+
+    return nullptr;
+  }
+
+  VVCDECAPI libvvcdec_ChromaFormat libHMDEC_get_chroma_format(libvvcdec_picture *pic)
+  {
+    if (pic == nullptr)
+      return LIBVVCDEC_CHROMA_UNKNOWN;
+    
+    // TODO
+    return LIBVVCDEC_CHROMA_UNKNOWN;
+  }
+
+  VVCDECAPI int libHMDEC_get_internal_bit_depth(libvvcdec_picture *pic, libvvcdec_ColorComponent c)
+  {
+    if (pic == nullptr)
+      return -1;
+
+    // TODO
+    (void)c;
+
+    return -1;
+  }
+
+} // extern "C"

--- a/source/App/libvvcdec/libvvcdec.cpp
+++ b/source/App/libvvcdec/libvvcdec.cpp
@@ -170,9 +170,10 @@ extern "C" {
     if (!d)
       return LIBVVCDEC_ERROR;
 
+    int iRet = 0;
     if (eof)
     {
-      auto iRet = d->flush();
+      iRet = d->flush();
       if( iRet != vvdec::VVDEC_OK && iRet != vvdec::VVDEC_EOF )
       {
         return LIBVVCDEC_ERROR;
@@ -181,17 +182,17 @@ extern "C" {
     else
     {
       if (!d->setAUData(data8, length))
-      return LIBVVCDEC_ERROR;
+        return LIBVVCDEC_ERROR;
 
-      auto iRet = d->decode();
+      iRet = d->decode();
 
-      if (iRet != vvdec::VVDEC_OK)
+      if (iRet != vvdec::VVDEC_OK && iRet != vvdec::VVDEC_TRY_AGAIN)
       {
         return LIBVVCDEC_ERROR;
       }
     }
 
-    checkOutputPictures = d->gotFrame();
+    checkOutputPictures = iRet != vvdec::VVDEC_TRY_AGAIN && d->gotFrame();
 
     // TODO: Do we still need this? I think we don't.
     (void)bNewPicture;
@@ -199,7 +200,7 @@ extern "C" {
     return LIBVVCDEC_OK;
   }
 
-  VVCDECAPI uint64_t libHMDEC_get_picture_POC(libvvcdec_context *decCtx)
+  VVCDECAPI uint64_t libvvcdec_get_picture_POC(libvvcdec_context *decCtx)
   {
     auto d = (vvcDecoderWrapper*)decCtx;
     if (!d || !d->gotFrame())
@@ -208,7 +209,7 @@ extern "C" {
     return d->getFrame()->m_uiSequenceNumber;
   }
 
-  VVCDECAPI uint32_t libHMDEC_get_picture_width(libvvcdec_context *decCtx, libvvcdec_ColorComponent c)
+  VVCDECAPI uint32_t libvvcdec_get_picture_width(libvvcdec_context *decCtx, libvvcdec_ColorComponent c)
   {
     auto d = (vvcDecoderWrapper*)decCtx;
     if (!d || !d->gotFrame())
@@ -222,7 +223,7 @@ extern "C" {
     return f->m_cComponent[idx].m_uiWidth;
   }
 
-  VVCDECAPI uint32_t libHMDEC_get_picture_height(libvvcdec_context *decCtx, libvvcdec_ColorComponent c)
+  VVCDECAPI uint32_t libvvcdec_get_picture_height(libvvcdec_context *decCtx, libvvcdec_ColorComponent c)
   {
     auto d = (vvcDecoderWrapper*)decCtx;
     if (!d || !d->gotFrame())
@@ -236,7 +237,7 @@ extern "C" {
     return f->m_cComponent[idx].m_uiHeight;
   }
 
-  VVCDECAPI int32_t libHMDEC_get_picture_stride(libvvcdec_context *decCtx, libvvcdec_ColorComponent c)
+  VVCDECAPI int32_t libvvcdec_get_picture_stride(libvvcdec_context *decCtx, libvvcdec_ColorComponent c)
   {
     auto d = (vvcDecoderWrapper*)decCtx;
     if (!d || !d->gotFrame())
@@ -250,7 +251,7 @@ extern "C" {
     return f->m_cComponent[idx].m_iStride;
   }
 
-  VVCDECAPI unsigned char* libHMDEC_get_picture_plane(libvvcdec_context *decCtx, libvvcdec_ColorComponent c)
+  VVCDECAPI unsigned char* libvvcdec_get_picture_plane(libvvcdec_context *decCtx, libvvcdec_ColorComponent c)
   {
     auto d = (vvcDecoderWrapper*)decCtx;
     if (!d || !d->gotFrame())
@@ -264,7 +265,7 @@ extern "C" {
     return f->m_cComponent[idx].m_pucBuffer;
   }
 
-  VVCDECAPI libvvcdec_ChromaFormat libHMDEC_get_picture_chroma_format(libvvcdec_context *decCtx)
+  VVCDECAPI libvvcdec_ChromaFormat libvvcdec_get_picture_chroma_format(libvvcdec_context *decCtx)
   {
     auto d = (vvcDecoderWrapper*)decCtx;
     if (!d || !d->gotFrame())
@@ -283,7 +284,7 @@ extern "C" {
     return LIBVVCDEC_CHROMA_UNKNOWN;
   }
 
-  VVCDECAPI uint32_t libHMDEC_get_picture_bit_depth(libvvcdec_context *decCtx, libvvcdec_ColorComponent c)
+  VVCDECAPI uint32_t libvvcdec_get_picture_bit_depth(libvvcdec_context *decCtx, libvvcdec_ColorComponent c)
   {
     auto d = (vvcDecoderWrapper*)decCtx;
     if (!d || !d->gotFrame())

--- a/source/App/libvvcdec/libvvcdec.cpp
+++ b/source/App/libvvcdec/libvvcdec.cpp
@@ -46,22 +46,24 @@ THE POSSIBILITY OF SUCH DAMAGE.
 
 #include "libvvcdec.h"
 
+#include "vvdec/vvdec.h"
+#include "vvdec/version.h"
+
 namespace
 {
 
 class vvcDecoderWrapper
 {
 public:
-  vvcDecoderWrapper()
+  vvcDecoderWrapper() = default;
+  ~vvcDecoderWrapper() = default;
+  int init()
   {
-
-  }
-  ~vvcDecoderWrapper()
-  {
-    
+    vvdec::VVDecParameter cVVDecParameter;
+    return this->cVVDec.init( cVVDecParameter );
   }
 private:
-
+  vvdec::VVDec cVVDec;
 };
 
 }
@@ -70,8 +72,7 @@ extern "C" {
 
   VVCDECAPI const char *libvvcdec_get_version(void)
   {
-    // TODO
-    return "";
+    return VVDEC_VERSION;
   }
 
   VVCDECAPI libvvcdec_context* libvvcdec_new_decoder(void)
@@ -79,6 +80,14 @@ extern "C" {
     auto decCtx = new vvcDecoderWrapper();
     if (!decCtx)
       return nullptr;
+
+    auto ret = decCtx->init();
+    if (ret != 0)
+    {
+      // Error initializing the decoder
+      delete decCtx;
+      return nullptr;
+    }
 
     return (libvvcdec_context*)decCtx;
   }

--- a/source/App/libvvcdec/libvvcdec.cpp
+++ b/source/App/libvvcdec/libvvcdec.cpp
@@ -85,7 +85,7 @@ extern "C" {
     return (libvvcdec_context*)decCtx;
   }
 
-  VVCDECAPI libvvcdec_error libvvcdec_set_logging_callback(libvvcdec_context* decCtx, libvvcdec_logging_callback callback, libvvcdec_loglevel loglevel)
+  VVCDECAPI libvvcdec_error libvvcdec_set_logging_callback(libvvcdec_context* decCtx, libvvcdec_logging_callback callback, void *userData, libvvcdec_loglevel loglevel)
   {
     auto d = (libvvcdec::vvcDecoderWrapper*)decCtx;
     if (!d || !callback)
@@ -93,7 +93,7 @@ extern "C" {
       return LIBVVCDEC_ERROR;
     }
 
-    d->setLogging(callback, loglevel);
+    d->setLogging(callback, userData, loglevel);
     return LIBVVCDEC_OK;
   }
 

--- a/source/App/libvvcdec/libvvcdec.h
+++ b/source/App/libvvcdec/libvvcdec.h
@@ -112,6 +112,19 @@ typedef enum
   LIBVVCDEC_ERROR_READ_ERROR   ///< There was an error reading the provided data
 } libvvcdec_error;
 
+typedef enum
+{
+  LIBVVCDEC_LOGLEVEL_SILENT  = 0,
+  LIBVVCDEC_LOGLEVEL_ERROR   = 1,
+  LIBVVCDEC_LOGLEVEL_WARNING = 2,
+  LIBVVCDEC_LOGLEVEL_INFO    = 3,
+  LIBVVCDEC_LOGLEVEL_NOTICE  = 4,
+  LIBVVCDEC_LOGLEVEL_VERBOSE = 5,
+  LIBVVCDEC_LOGLEVEL_DETAILS = 6
+} libvvcdec_loglevel;
+
+typedef void (*libvvcdec_logging_callback)(void*, int, const char*);
+
 /** Get info about the decoder version (e.g. "2.0")
  */
 VVCDECAPI const char *libvvcdec_get_version(void);
@@ -126,6 +139,10 @@ typedef void libvvcdec_context;
   * \return Returns a pointer to the new decoder or NULL if an error occurred.
   */
 VVCDECAPI libvvcdec_context* libvvcdec_new_decoder(void);
+
+/** Set a logging callback.
+ */
+VVCDECAPI libvvcdec_error libvvcdec_set_logging_callback(libvvcdec_context* decCtx, libvvcdec_logging_callback callback, libvvcdec_loglevel loglevel);
 
 /** Destroy an existing decoder.
  * \param decCtx The decoder context to destroy that was created with libvvcdec_new_decoder

--- a/source/App/libvvcdec/libvvcdec.h
+++ b/source/App/libvvcdec/libvvcdec.h
@@ -142,7 +142,7 @@ VVCDECAPI libvvcdec_context* libvvcdec_new_decoder(void);
 
 /** Set a logging callback.
  */
-VVCDECAPI libvvcdec_error libvvcdec_set_logging_callback(libvvcdec_context* decCtx, libvvcdec_logging_callback callback, libvvcdec_loglevel loglevel);
+VVCDECAPI libvvcdec_error libvvcdec_set_logging_callback(libvvcdec_context* decCtx, libvvcdec_logging_callback callback, void *userData, libvvcdec_loglevel loglevel);
 
 /** Destroy an existing decoder.
  * \param decCtx The decoder context to destroy that was created with libvvcdec_new_decoder

--- a/source/App/libvvcdec/libvvcdec.h
+++ b/source/App/libvvcdec/libvvcdec.h
@@ -66,7 +66,7 @@ THE POSSIBILITY OF SUCH DAMAGE.
  *   }
  *
  *   bool new_picture, check_output;
- *   if (libvvcdec_push_nal_unit(decCtx, data, length, eof, new_picture, check_output) != LIBVVCDEC_OK)
+ *   if (libvvcdec_push_nal_unit(decCtx, data, length, check_output) != LIBVVCDEC_OK)
  *     handle_the_error();
  *   if (!new_picture)
  *   {
@@ -137,14 +137,12 @@ VVCDECAPI libvvcdec_error libvvcdec_free_decoder(libvvcdec_context* decCtx);
  * This will perform decoding of the NAL unit. It must be exactly one NAL unit and the data array must
  * not be empty.
  * \param decCtx The decoder context that was created with libvvcdec_new_decoder
- * \param data8 The raw byte data from the NAL unit starting with the first byte of the NAL unit header.
+ * \param data8 The raw byte data from the NAL unit starting with the first byte of the NAL unit header. Push nullptr to signal EOF.
  * \param length The length in number of bytes in the data
- * \param eof Is this NAL the last one in the bitstream?
- * \param bNewPicture This bool is set by the function if the NAL unit must be pushed to the decoder again after reading frames.
  * \param checkOutputPictures This bool is set by the function if pictures might be available (see libvvcdec_get_picture).
  * \return An error code or LIBVVCDEC_OK if no error occured
  */
-VVCDECAPI libvvcdec_error libvvcdec_push_nal_unit(libvvcdec_context *decCtx, const unsigned char* data8, int length, bool eof, bool &bNewPicture, bool &checkOutputPictures);
+VVCDECAPI libvvcdec_error libvvcdec_push_nal_unit(libvvcdec_context *decCtx, const unsigned char* data8, int length, bool &checkOutputPictures);
 
 /** This private structure represents a picture.
  * You can save a pointer to it and use all the following functions to access it

--- a/source/App/libvvcdec/libvvcdec.h
+++ b/source/App/libvvcdec/libvvcdec.h
@@ -97,6 +97,7 @@ extern "C" {
 #endif
 
 //#include <stdint.h>
+#include <cstdint>
 
 #if defined(_MSC_VER)
 #define VVCDECAPI __declspec(dllexport)
@@ -143,7 +144,7 @@ VVCDECAPI libvvcdec_error libvvcdec_free_decoder(libvvcdec_context* decCtx);
  * \param checkOutputPictures This bool is set by the function if pictures might be available (see libvvcdec_get_picture).
  * \return An error code or LIBVVCDEC_OK if no error occured
  */
-VVCDECAPI libvvcdec_error libvvcdec_push_nal_unit(libvvcdec_context *decCtx, const void* data8, int length, bool eof, bool &bNewPicture, bool &checkOutputPictures);
+VVCDECAPI libvvcdec_error libvvcdec_push_nal_unit(libvvcdec_context *decCtx, const unsigned char* data8, int length, bool eof, bool &bNewPicture, bool &checkOutputPictures);
 
 /** This private structure represents a picture.
  * You can save a pointer to it and use all the following functions to access it
@@ -160,21 +161,13 @@ typedef enum
   LIBVVCDEC_CHROMA_V
 } libvvcdec_ColorComponent;
 
-/** Get the next output picture from the decoder if one is read for output.
- * When the checkOutputPictures flag was set in the last call of libvvcdec_push_nal_unit, call this
- * function until no more pictures are available.
- * \param decCtx The decoder context that was created with libvvcdec_new_decoder
- * \return Returns a pointer to a libvvcdec_picture or NULL if no picture is ready for output.
-*/
-VVCDECAPI libvvcdec_picture *libvvcdec_get_picture(libvvcdec_context* decCtx);
-
 /** Get the POC of the given picture.
  * By definition, the POC of pictures obtained from libvvcdec_get_picture must be strictly increasing.
  * However, the increase may be non-linear.
  * \param pic The libvvcdec_picture that was obtained using libvvcdec_get_picture
  * \return The picture order count (POC) of the picture.
  */
-VVCDECAPI int libvvcdec_get_POC(libvvcdec_picture *pic);
+VVCDECAPI uint64_t libHMDEC_get_picture_POC(libvvcdec_context *decCtx);
 
 /** Get the width/height in pixel of the given picture.
  * This is including internal padding and the conformance window.
@@ -182,11 +175,11 @@ VVCDECAPI int libvvcdec_get_POC(libvvcdec_picture *pic);
  * \param c The color component. Note: The width/height for the luma and chroma components can differ.
  * \return The width/height of the picture in pixel.
  */
-VVCDECAPI int libvvcdec_get_picture_width(libvvcdec_picture *pic, libvvcdec_ColorComponent c);
+VVCDECAPI uint32_t libHMDEC_get_picture_width(libvvcdec_context *decCtx, libvvcdec_ColorComponent c);
 
 /** @copydoc libvvcdec_get_picture_width(libvvcdec_picture *,libvvcdec_ColorComponent)
  */
-VVCDECAPI int libvvcdec_get_picture_height(libvvcdec_picture *pic, libvvcdec_ColorComponent c);
+VVCDECAPI uint32_t libHMDEC_get_picture_height(libvvcdec_context *decCtx, libvvcdec_ColorComponent c);
 
 /** Get the picture stride (the number of values to reach the next Y-line).
  * Do not confuse the stride and the width of the picture. Internally, the picture buffer may be wider than the output width.
@@ -194,7 +187,7 @@ VVCDECAPI int libvvcdec_get_picture_height(libvvcdec_picture *pic, libvvcdec_Col
  * \param c The color component. Note: The stride for the luma and chroma components can differ.
  * \return The picture stride
  */
-VVCDECAPI int libvvcdec_get_picture_stride(libvvcdec_picture *pic, libvvcdec_ColorComponent c);
+VVCDECAPI int32_t libHMDEC_get_picture_stride(libvvcdec_context *decCtx, libvvcdec_ColorComponent c);
 
 /** Get access to the raw image plane.
  * The pointer will point to the top left pixel position. You can read "width" pixels from it.
@@ -205,7 +198,7 @@ VVCDECAPI int libvvcdec_get_picture_stride(libvvcdec_picture *pic, libvvcdec_Col
  * \param c The color component to access. Note that the width and stride may be different for the chroma components.
  * \return A pointer to the values as short. For 8-bit output, the upper 8 bit are zero and can be ignored.
  */
-VVCDECAPI short *libvvcdec_get_image_plane(libvvcdec_picture *pic, libvvcdec_ColorComponent c);
+VVCDECAPI unsigned char *libHMDEC_get_picture_plane(libvvcdec_context *decCtx, libvvcdec_ColorComponent c);
 
 /** The YUV subsampling types
 */
@@ -222,14 +215,14 @@ typedef enum
  * \param pic The libvvcdec_picture that was obtained using libvvcdec_get_picture.
  * \return The pictures subsampling type
  */
-VVCDECAPI libvvcdec_ChromaFormat libvvcdec_get_chroma_format(libvvcdec_picture *pic);
+VVCDECAPI libvvcdec_ChromaFormat libHMDEC_get_picture_chroma_format(libvvcdec_context *decCtx);
 
 /** Get the bit depth which is used internally for the given color component and the given picture.
  * \param pic The picture to get the internal bit depth from
  * \param c The color component
  * \return The internal bit depth
  */
-VVCDECAPI int libvvcdec_get_internal_bit_depth(libvvcdec_picture *pic, libvvcdec_ColorComponent c);
+VVCDECAPI uint32_t libHMDEC_get_picture_bit_depth(libvvcdec_context *decCtx, libvvcdec_ColorComponent c);
 
 #ifdef __cplusplus
 }

--- a/source/App/libvvcdec/libvvcdec.h
+++ b/source/App/libvvcdec/libvvcdec.h
@@ -1,0 +1,236 @@
+/* -----------------------------------------------------------------------------
+The copyright in this software is being made available under the BSD
+License, included below. No patent rights, trademark rights and/or 
+other Intellectual Property Rights other than the copyrights concerning 
+the Software are granted under this license.
+
+For any license concerning other Intellectual Property rights than the software, 
+especially patent licenses, a separate Agreement needs to be closed. 
+For more information please contact:
+
+Fraunhofer Heinrich Hertz Institute
+Einsteinufer 37
+10587 Berlin, Germany
+www.hhi.fraunhofer.de/vvc
+vvc@hhi.fraunhofer.de
+
+Copyright (c) 2018-2020, Fraunhofer-Gesellschaft zur Förderung der angewandten Forschung e.V. 
+All rights reserved.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are met:
+
+ * Redistributions of source code must retain the above copyright notice,
+   this list of conditions and the following disclaimer.
+ * Redistributions in binary form must reproduce the above copyright notice,
+   this list of conditions and the following disclaimer in the documentation
+   and/or other materials provided with the distribution.
+ * Neither the name of Fraunhofer nor the names of its contributors may
+   be used to endorse or promote products derived from this software without
+   specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS
+BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+THE POSSIBILITY OF SUCH DAMAGE.
+
+
+------------------------------------------------------------------------------------------- */
+
+#pragma once
+
+/** \file libvvcdec.h
+ * Decoder library public API definition.
+ * This public API defines the functions that are exported by the dynamic library libvvcdec.
+ * The API can be used like this:
+ * \code{.cpp}
+ * libvvcdec_context *decCtx = libvvcdec_new_decoder();
+ * bool eof = false;
+ * uint8_t *data = NULL;
+ * int length = -1;
+ * while (!eof)
+ * {
+ *   if (data == NULL && length == -1)
+ *   {
+ *     // Get the next NAL unit to push
+ *     data = get_nal_unit_data();
+ *     length = get_lenght_of_nal_unit_data();
+ *     eof = is_this_the_last_nal_unit();
+ *   }
+ *
+ *   bool new_picture, check_output;
+ *   if (libvvcdec_push_nal_unit(decCtx, data, length, eof, new_picture, check_output) != LIBVVCDEC_OK)
+ *     handle_the_error();
+ *   if (!new_picture)
+ *   {
+ *     // The NAL was consumed and the next NAL can be pushed in the next call to libvvcdec_push_nal_unit
+ *     data = NULL;
+ *     legth = -1;
+ *   }
+ *
+ *   // Next, check the output
+ *   if (check_output)
+ *   {
+ *     libvvcdec_picture *pic = libvvcdec_get_picture(decCtx);
+ *     while(pic != NULL)
+ *     {
+ *       // Do something with the picture...
+ *       int width = libvvcdec_get_picture_width(pic, LIBVVCDEC_LUMA);
+ *       // Go to the next picture until no more pictures are present.
+ *       pic = libvvcdec_get_picture(decCtx);
+ *     }
+ *   }
+ * }
+ * libvvcdec_free_decoder(decCtx);
+ * \endcode
+ */
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+//#include <stdint.h>
+
+#if defined(_MSC_VER)
+#define VVCDECAPI __declspec(dllexport)
+#else
+#define VVCDECAPI
+#endif
+
+typedef enum
+{
+  LIBVVCDEC_OK = 0,            ///< No error occured
+  LIBVVCDEC_ERROR,             ///< There was an unspecified error
+  LIBVVCDEC_ERROR_READ_ERROR   ///< There was an error reading the provided data
+} libvvcdec_error;
+
+/** Get info about the decoder version (e.g. "2.0")
+ */
+VVCDECAPI const char *libvvcdec_get_version(void);
+
+/** This private structure is the decoder.
+ * You can save a pointer to it and use all the following functions to access it
+ * but it is not further defined as part of the public API.
+ */
+typedef void libvvcdec_context;
+
+/** Allocate and initialize a new decoder.
+  * \return Returns a pointer to the new decoder or NULL if an error occurred.
+  */
+VVCDECAPI libvvcdec_context* libvvcdec_new_decoder(void);
+
+/** Destroy an existing decoder.
+ * \param decCtx The decoder context to destroy that was created with libvvcdec_new_decoder
+ * \return Return an error code or LIBVVCDEC_OK if no error occured.
+ */
+VVCDECAPI libvvcdec_error libvvcdec_free_decoder(libvvcdec_context* decCtx);
+
+/** Push a single NAL unit into the decoder (excluding the start code but including the NAL unit header).
+ * This will perform decoding of the NAL unit. It must be exactly one NAL unit and the data array must
+ * not be empty.
+ * \param decCtx The decoder context that was created with libvvcdec_new_decoder
+ * \param data8 The raw byte data from the NAL unit starting with the first byte of the NAL unit header.
+ * \param length The length in number of bytes in the data
+ * \param eof Is this NAL the last one in the bitstream?
+ * \param bNewPicture This bool is set by the function if the NAL unit must be pushed to the decoder again after reading frames.
+ * \param checkOutputPictures This bool is set by the function if pictures might be available (see libvvcdec_get_picture).
+ * \return An error code or LIBVVCDEC_OK if no error occured
+ */
+VVCDECAPI libvvcdec_error libvvcdec_push_nal_unit(libvvcdec_context *decCtx, const void* data8, int length, bool eof, bool &bNewPicture, bool &checkOutputPictures);
+
+/** This private structure represents a picture.
+ * You can save a pointer to it and use all the following functions to access it
+ * but it is not further defined as part of the public API.
+ */
+typedef void libvvcdec_picture;
+
+/** The YUV color components
+ */
+typedef enum
+{
+  LIBVVCDEC_LUMA = 0,
+  LIBVVCDEC_CHROMA_U,
+  LIBVVCDEC_CHROMA_V
+} libvvcdec_ColorComponent;
+
+/** Get the next output picture from the decoder if one is read for output.
+ * When the checkOutputPictures flag was set in the last call of libvvcdec_push_nal_unit, call this
+ * function until no more pictures are available.
+ * \param decCtx The decoder context that was created with libvvcdec_new_decoder
+ * \return Returns a pointer to a libvvcdec_picture or NULL if no picture is ready for output.
+*/
+VVCDECAPI libvvcdec_picture *libvvcdec_get_picture(libvvcdec_context* decCtx);
+
+/** Get the POC of the given picture.
+ * By definition, the POC of pictures obtained from libvvcdec_get_picture must be strictly increasing.
+ * However, the increase may be non-linear.
+ * \param pic The libvvcdec_picture that was obtained using libvvcdec_get_picture
+ * \return The picture order count (POC) of the picture.
+ */
+VVCDECAPI int libvvcdec_get_POC(libvvcdec_picture *pic);
+
+/** Get the width/height in pixel of the given picture.
+ * This is including internal padding and the conformance window.
+ * \param pic The libvvcdec_picture that was obtained using libvvcdec_get_picture.
+ * \param c The color component. Note: The width/height for the luma and chroma components can differ.
+ * \return The width/height of the picture in pixel.
+ */
+VVCDECAPI int libvvcdec_get_picture_width(libvvcdec_picture *pic, libvvcdec_ColorComponent c);
+
+/** @copydoc libvvcdec_get_picture_width(libvvcdec_picture *,libvvcdec_ColorComponent)
+ */
+VVCDECAPI int libvvcdec_get_picture_height(libvvcdec_picture *pic, libvvcdec_ColorComponent c);
+
+/** Get the picture stride (the number of values to reach the next Y-line).
+ * Do not confuse the stride and the width of the picture. Internally, the picture buffer may be wider than the output width.
+ * \param pic The libvvcdec_picture that was obtained using libvvcdec_get_picture.
+ * \param c The color component. Note: The stride for the luma and chroma components can differ.
+ * \return The picture stride
+ */
+VVCDECAPI int libvvcdec_get_picture_stride(libvvcdec_picture *pic, libvvcdec_ColorComponent c);
+
+/** Get access to the raw image plane.
+ * The pointer will point to the top left pixel position. You can read "width" pixels from it.
+ * Add "stride" to the pointer to advance to the corresponding pixel in the next line.
+ * Internally, there may be padding/a conformance window. The returned pointer may thusly not point
+ * to the top left pixel of the internal buffer.
+ * \param pic The libvvcdec_picture that was obtained using libvvcdec_get_picture.
+ * \param c The color component to access. Note that the width and stride may be different for the chroma components.
+ * \return A pointer to the values as short. For 8-bit output, the upper 8 bit are zero and can be ignored.
+ */
+VVCDECAPI short *libvvcdec_get_image_plane(libvvcdec_picture *pic, libvvcdec_ColorComponent c);
+
+/** The YUV subsampling types
+*/
+typedef enum
+{
+  LIBVVCDEC_CHROMA_400 = 0,  ///< Monochrome (no chroma components)
+  LIBVVCDEC_CHROMA_420,      ///< 4:2:0 - Chroma subsampled by a factor of 2 in horizontal and vertical direction
+  LIBVVCDEC_CHROMA_422,      ///< 4:2:2 - Chroma subsampled by a factor of 2 in horizontal direction
+  LIBVVCDEC_CHROMA_444,      ///< 4:4:4 - No chroma subsampling
+  LIBVVCDEC_CHROMA_UNKNOWN
+} libvvcdec_ChromaFormat;
+
+/** Get the YUV subsampling type of the given picture.
+ * \param pic The libvvcdec_picture that was obtained using libvvcdec_get_picture.
+ * \return The pictures subsampling type
+ */
+VVCDECAPI libvvcdec_ChromaFormat libvvcdec_get_chroma_format(libvvcdec_picture *pic);
+
+/** Get the bit depth which is used internally for the given color component and the given picture.
+ * \param pic The picture to get the internal bit depth from
+ * \param c The color component
+ * \return The internal bit depth
+ */
+VVCDECAPI int libvvcdec_get_internal_bit_depth(libvvcdec_picture *pic, libvvcdec_ColorComponent c);
+
+#ifdef __cplusplus
+}
+#endif

--- a/source/App/libvvcdec/libvvcdec.h
+++ b/source/App/libvvcdec/libvvcdec.h
@@ -167,7 +167,7 @@ typedef enum
  * \param pic The libvvcdec_picture that was obtained using libvvcdec_get_picture
  * \return The picture order count (POC) of the picture.
  */
-VVCDECAPI uint64_t libHMDEC_get_picture_POC(libvvcdec_context *decCtx);
+VVCDECAPI uint64_t libvvcdec_get_picture_POC(libvvcdec_context *decCtx);
 
 /** Get the width/height in pixel of the given picture.
  * This is including internal padding and the conformance window.
@@ -175,11 +175,11 @@ VVCDECAPI uint64_t libHMDEC_get_picture_POC(libvvcdec_context *decCtx);
  * \param c The color component. Note: The width/height for the luma and chroma components can differ.
  * \return The width/height of the picture in pixel.
  */
-VVCDECAPI uint32_t libHMDEC_get_picture_width(libvvcdec_context *decCtx, libvvcdec_ColorComponent c);
+VVCDECAPI uint32_t libvvcdec_get_picture_width(libvvcdec_context *decCtx, libvvcdec_ColorComponent c);
 
 /** @copydoc libvvcdec_get_picture_width(libvvcdec_picture *,libvvcdec_ColorComponent)
  */
-VVCDECAPI uint32_t libHMDEC_get_picture_height(libvvcdec_context *decCtx, libvvcdec_ColorComponent c);
+VVCDECAPI uint32_t libvvcdec_get_picture_height(libvvcdec_context *decCtx, libvvcdec_ColorComponent c);
 
 /** Get the picture stride (the number of values to reach the next Y-line).
  * Do not confuse the stride and the width of the picture. Internally, the picture buffer may be wider than the output width.
@@ -187,7 +187,7 @@ VVCDECAPI uint32_t libHMDEC_get_picture_height(libvvcdec_context *decCtx, libvvc
  * \param c The color component. Note: The stride for the luma and chroma components can differ.
  * \return The picture stride
  */
-VVCDECAPI int32_t libHMDEC_get_picture_stride(libvvcdec_context *decCtx, libvvcdec_ColorComponent c);
+VVCDECAPI int32_t libvvcdec_get_picture_stride(libvvcdec_context *decCtx, libvvcdec_ColorComponent c);
 
 /** Get access to the raw image plane.
  * The pointer will point to the top left pixel position. You can read "width" pixels from it.
@@ -198,7 +198,7 @@ VVCDECAPI int32_t libHMDEC_get_picture_stride(libvvcdec_context *decCtx, libvvcd
  * \param c The color component to access. Note that the width and stride may be different for the chroma components.
  * \return A pointer to the values as short. For 8-bit output, the upper 8 bit are zero and can be ignored.
  */
-VVCDECAPI unsigned char *libHMDEC_get_picture_plane(libvvcdec_context *decCtx, libvvcdec_ColorComponent c);
+VVCDECAPI unsigned char *libvvcdec_get_picture_plane(libvvcdec_context *decCtx, libvvcdec_ColorComponent c);
 
 /** The YUV subsampling types
 */
@@ -215,14 +215,14 @@ typedef enum
  * \param pic The libvvcdec_picture that was obtained using libvvcdec_get_picture.
  * \return The pictures subsampling type
  */
-VVCDECAPI libvvcdec_ChromaFormat libHMDEC_get_picture_chroma_format(libvvcdec_context *decCtx);
+VVCDECAPI libvvcdec_ChromaFormat libvvcdec_get_picture_chroma_format(libvvcdec_context *decCtx);
 
 /** Get the bit depth which is used internally for the given color component and the given picture.
  * \param pic The picture to get the internal bit depth from
  * \param c The color component
  * \return The internal bit depth
  */
-VVCDECAPI uint32_t libHMDEC_get_picture_bit_depth(libvvcdec_context *decCtx, libvvcdec_ColorComponent c);
+VVCDECAPI uint32_t libvvcdec_get_picture_bit_depth(libvvcdec_context *decCtx, libvvcdec_ColorComponent c);
 
 #ifdef __cplusplus
 }

--- a/source/App/libvvcdec/vvcDecoderWrapper.cpp
+++ b/source/App/libvvcdec/vvcDecoderWrapper.cpp
@@ -46,6 +46,8 @@ THE POSSIBILITY OF SUCH DAMAGE.
 
 #include "vvcDecoderWrapper.h"
 
+#include <algorithm>
+
 namespace libvvcdec
 {
 

--- a/source/App/libvvcdec/vvcDecoderWrapper.cpp
+++ b/source/App/libvvcdec/vvcDecoderWrapper.cpp
@@ -1,0 +1,157 @@
+/* -----------------------------------------------------------------------------
+The copyright in this software is being made available under the BSD
+License, included below. No patent rights, trademark rights and/or 
+other Intellectual Property Rights other than the copyrights concerning 
+the Software are granted under this license.
+
+For any license concerning other Intellectual Property rights than the software, 
+especially patent licenses, a separate Agreement needs to be closed. 
+For more information please contact:
+
+Fraunhofer Heinrich Hertz Institute
+Einsteinufer 37
+10587 Berlin, Germany
+www.hhi.fraunhofer.de/vvc
+vvc@hhi.fraunhofer.de
+
+Copyright (c) 2018-2020, Fraunhofer-Gesellschaft zur Förderung der angewandten Forschung e.V. 
+All rights reserved.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are met:
+
+ * Redistributions of source code must retain the above copyright notice,
+   this list of conditions and the following disclaimer.
+ * Redistributions in binary form must reproduce the above copyright notice,
+   this list of conditions and the following disclaimer in the documentation
+   and/or other materials provided with the distribution.
+ * Neither the name of Fraunhofer nor the names of its contributors may
+   be used to endorse or promote products derived from this software without
+   specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS
+BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+THE POSSIBILITY OF SUCH DAMAGE.
+
+
+------------------------------------------------------------------------------------------- */
+
+#include "vvcDecoderWrapper.h"
+
+namespace libvvcdec
+{
+
+vvcDecoderWrapper::vvcDecoderWrapper()
+{
+  this->cAccessUnit.m_pucBuffer = nullptr;
+  this->cAccessUnit.m_iBufSize = 0;
+  this->cAccessUnit.m_uiCts = 0;
+  this->cAccessUnit.m_bCtsValid = true;
+  this->cAccessUnit.m_uiDts = 0;
+  this->cAccessUnit.m_bDtsValid = true;
+}
+
+vvcDecoderWrapper::~vvcDecoderWrapper()
+{
+  this->closeDecoder();
+}
+
+int vvcDecoderWrapper::init()
+{
+  vvdec::VVDecParameter cVVDecParameter;
+  return this->cVVDec.init( cVVDecParameter );
+}
+
+bool vvcDecoderWrapper::setAUData(const unsigned char* data8, int length)
+{
+  if (length > this->cAccessUnit.m_iBufSize)
+  {
+    // Allocate a new big enough buffer
+    if (this->cAccessUnit.m_pucBuffer != nullptr)
+    {
+      delete[] this->cAccessUnit.m_pucBuffer;
+    }
+    this->cAccessUnit.m_pucBuffer = new unsigned char[length];
+    if (this->cAccessUnit.m_pucBuffer == nullptr)
+    {
+      this->cAccessUnit.m_iBufSize = 0;
+      return false;
+    }
+    this->cAccessUnit.m_iBufSize = length;
+  }
+  std::copy_n( data8 , length, this->cAccessUnit.m_pucBuffer);
+  this->cAccessUnit.m_iUsedSize = length;
+  return true;
+}
+
+int vvcDecoderWrapper::decode()
+{
+  if (this->flushing)
+  {
+    return vvdec::VVDEC_ERR_UNSPECIFIED;
+  }
+  this->unrefCurrentFrame();
+  return this->cVVDec.decode( this->cAccessUnit, &pcFrame );
+}
+
+int vvcDecoderWrapper::flush()
+{
+  this->unrefCurrentFrame();
+  this->flushing = true;
+  auto ret = this->cVVDec.flush( &this->pcFrame );
+  if (this->pcFrame == nullptr)
+  {
+    this->closeDecoder();
+  }
+  return ret;
+}
+
+bool vvcDecoderWrapper::gotFrame() const
+{
+  return this->pcFrame != nullptr && this->pcFrame->m_bCtsValid;
+}
+
+vvdec::Frame* vvcDecoderWrapper::getFrame() const
+{
+  return this->pcFrame;
+}
+
+void vvcDecoderWrapper::setLogging(libvvcdec_logging_callback callback, libvvcdec_loglevel level)
+{
+  this->loggingCallback = callback;
+  this->loglevel = level;
+}
+
+void vvcDecoderWrapper::unrefCurrentFrame()
+{
+  if (this->pcFrame != nullptr)
+  {
+    this->cVVDec.objectUnref( this->pcFrame );
+    this->pcFrame = nullptr;
+  }
+}
+
+void vvcDecoderWrapper::closeDecoder()
+{
+  this->unrefCurrentFrame();
+  if (this->pcFrame != nullptr)
+  {
+    this->cVVDec.objectUnref( this->pcFrame );
+    this->pcFrame = nullptr;
+  }
+  if (this->cAccessUnit.m_pucBuffer != nullptr)
+  {
+    delete [] this->cAccessUnit.m_pucBuffer;
+  }
+  this->isEnd = true;
+}
+
+}

--- a/source/App/libvvcdec/vvcDecoderWrapper.cpp
+++ b/source/App/libvvcdec/vvcDecoderWrapper.cpp
@@ -157,11 +157,12 @@ void vvcDecoderWrapper::unrefCurrentFrame()
 
 void vvcDecoderWrapper::closeDecoder()
 {
-  this->logMessage("Closing deocder", LIBVVCDEC_LOGLEVEL_INFO);
+  this->logMessage("Closing decoder", LIBVVCDEC_LOGLEVEL_INFO);
   this->unrefCurrentFrame();
   if (this->cAccessUnit.m_pucBuffer != nullptr)
   {
     delete [] this->cAccessUnit.m_pucBuffer;
+    this->cAccessUnit.m_pucBuffer = nullptr;
   }
   this->isEnd = true;
 }

--- a/source/App/libvvcdec/vvcDecoderWrapper.cpp
+++ b/source/App/libvvcdec/vvcDecoderWrapper.cpp
@@ -115,7 +115,7 @@ int vvcDecoderWrapper::decode()
 
 int vvcDecoderWrapper::flush()
 {
-  this->logMessage("Start flushing", LIBVVCDEC_LOGLEVEL_INFO);
+  this->logMessage("Flush decoder", LIBVVCDEC_LOGLEVEL_INFO);
   this->unrefCurrentFrame();
   this->flushing = true;
   auto ret = this->cVVDec.flush( &this->pcFrame );

--- a/source/App/libvvcdec/vvcDecoderWrapper.h
+++ b/source/App/libvvcdec/vvcDecoderWrapper.h
@@ -1,0 +1,85 @@
+/* -----------------------------------------------------------------------------
+The copyright in this software is being made available under the BSD
+License, included below. No patent rights, trademark rights and/or 
+other Intellectual Property Rights other than the copyrights concerning 
+the Software are granted under this license.
+
+For any license concerning other Intellectual Property rights than the software, 
+especially patent licenses, a separate Agreement needs to be closed. 
+For more information please contact:
+
+Fraunhofer Heinrich Hertz Institute
+Einsteinufer 37
+10587 Berlin, Germany
+www.hhi.fraunhofer.de/vvc
+vvc@hhi.fraunhofer.de
+
+Copyright (c) 2018-2020, Fraunhofer-Gesellschaft zur Förderung der angewandten Forschung e.V. 
+All rights reserved.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are met:
+
+ * Redistributions of source code must retain the above copyright notice,
+   this list of conditions and the following disclaimer.
+ * Redistributions in binary form must reproduce the above copyright notice,
+   this list of conditions and the following disclaimer in the documentation
+   and/or other materials provided with the distribution.
+ * Neither the name of Fraunhofer nor the names of its contributors may
+   be used to endorse or promote products derived from this software without
+   specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS
+BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+THE POSSIBILITY OF SUCH DAMAGE.
+
+
+------------------------------------------------------------------------------------------- */
+
+#pragma once
+
+#include "libvvcdec.h"
+#include "vvdec/vvdec.h"
+
+namespace libvvcdec
+{
+
+class vvcDecoderWrapper
+{
+public:
+  vvcDecoderWrapper();
+  ~vvcDecoderWrapper();
+  
+  int init();
+  
+  bool setAUData(const unsigned char* data8, int length);
+  int decode();
+  int flush();
+  
+  bool gotFrame() const;
+  vvdec::Frame* getFrame() const;
+  
+  void setLogging(libvvcdec_logging_callback callback, libvvcdec_loglevel level);
+
+private:
+  void unrefCurrentFrame();
+  void closeDecoder();
+  
+  vvdec::VVDec cVVDec;
+  vvdec::AccessUnit cAccessUnit;
+  vvdec::Frame* pcFrame {nullptr};
+  bool flushing {false};
+  bool isEnd {false};
+  libvvcdec_logging_callback loggingCallback {};
+  libvvcdec_loglevel loglevel{LIBVVCDEC_LOGLEVEL_SILENT};
+};
+
+}

--- a/source/App/libvvcdec/vvcDecoderWrapper.h
+++ b/source/App/libvvcdec/vvcDecoderWrapper.h
@@ -67,12 +67,13 @@ public:
   bool gotFrame() const;
   vvdec::Frame* getFrame() const;
   
-  void setLogging(libvvcdec_logging_callback callback, libvvcdec_loglevel level);
+  void setLogging(libvvcdec_logging_callback callback, void *userData, libvvcdec_loglevel level);
 
 private:
   void unrefCurrentFrame();
   void closeDecoder();
-  
+  void logMessage(std::string msg, libvvcdec_loglevel level);
+
   vvdec::VVDec cVVDec;
   vvdec::AccessUnit cAccessUnit;
   vvdec::Frame* pcFrame {nullptr};
@@ -80,6 +81,7 @@ private:
   bool isEnd {false};
   libvvcdec_logging_callback loggingCallback {};
   libvvcdec_loglevel loglevel{LIBVVCDEC_LOGLEVEL_SILENT};
+  void *loggingUserData {};
 };
 
 }

--- a/source/Lib/CommonLib/Rom.cpp
+++ b/source/Lib/CommonLib/Rom.cpp
@@ -77,6 +77,8 @@ TimeProfiler2D *g_timeProfiler = nullptr;
 //! \ingroup CommonLib
 //! \{
 
+std::atomic<int> romInitialized = 0;
+
 MsgLevel g_verbosity = VERBOSE;
 
 const char* nalUnitTypeToString(NalUnitType type)
@@ -254,6 +256,21 @@ void initROM()
   }
 
 #endif
+
+  // This is the hack for having global variables in a shared library. Having global
+  // variables in a shared library is a very bad idea in general. The clean solution
+  // would be:
+  //  A: Have a struct that contains all the global variables and pass a const reference
+  //     to them into each class/function that needs them.
+  //  B: For really const values just precalculate them all and put them intot a header
+  //     to include everywhere where needed.
+  if (romInitialized > 0)
+  {
+    romInitialized++;
+    return;
+  }
+  romInitialized++;
+
   const SizeIndexInfoLog2 &sizeInfo = g_sizeIdxInfo;
 
   {
@@ -376,6 +393,12 @@ void initROM()
 
 void destroyROM()
 {
+  romInitialized--;
+  if (romInitialized > 0)
+  {
+    return;
+  }
+
   const SizeIndexInfoLog2 &sizeInfo = g_sizeIdxInfo;
   // initialize CoefTopLeftDiagScan8x8 for LFNST
   for( uint32_t blockWidthIdx = 0; blockWidthIdx < sizeInfo.numAllWidths(); blockWidthIdx++ )

--- a/source/Lib/CommonLib/Rom.cpp
+++ b/source/Lib/CommonLib/Rom.cpp
@@ -77,7 +77,7 @@ TimeProfiler2D *g_timeProfiler = nullptr;
 //! \ingroup CommonLib
 //! \{
 
-std::atomic<int> romInitialized = 0;
+std::atomic<int> romInitialized(0);
 
 MsgLevel g_verbosity = VERBOSE;
 

--- a/source/Lib/CommonLib/Rom.h
+++ b/source/Lib/CommonLib/Rom.h
@@ -54,6 +54,7 @@ THE POSSIBILITY OF SUCH DAMAGE.
 #include "CommonDef.h"
 #include "Common.h"
 
+#include <atomic>
 #include <stdio.h>
 #include <iostream>
 
@@ -67,6 +68,8 @@ THE POSSIBILITY OF SUCH DAMAGE.
 
 void         initROM();
 void         destroyROM();
+
+extern std::atomic<int> romInitialized;
 
 // ====================================================================================================================
 // Data structure related table & variable

--- a/source/Lib/vvdec/vvdecimpl.cpp
+++ b/source/Lib/vvdec/vvdecimpl.cpp
@@ -991,6 +991,7 @@ int VVDecImpl::xCreateFrame( Frame& rcFrame, const CPelUnitBuf& rcPicBuf, uint32
         rcFrame.m_cComponent[VVC_CT_U].m_iStride          = m_bCreateNewPicBuf ? uiCWidth * rcFrame.m_cComponent[CHANNEL_TYPE_CHROMA].m_uiBytesPerSample
                                                                                   : rcPicBuf.get(COMPONENT_Cb).stride * rcFrame.m_cComponent[VVC_CT_Y].m_uiBytesPerSample;
         rcFrame.m_cComponent[VVC_CT_U].m_uiByteOffset     = rcFrame.m_cComponent[VVC_CT_Y].m_iStride * rcFrame.m_cComponent[VVC_CT_Y].m_uiHeight;
+        rcFrame.m_cComponent[VVC_CT_U].m_uiBitDepth       = rcBitDepths.recon[CHANNEL_TYPE_CHROMA];
 
         uint32_t nCSize = rcFrame.m_cComponent[VVC_CT_U].m_iStride*uiCHeight;
 
@@ -1001,6 +1002,7 @@ int VVDecImpl::xCreateFrame( Frame& rcFrame, const CPelUnitBuf& rcPicBuf, uint32
         rcFrame.m_cComponent[VVC_CT_V].m_iStride          = m_bCreateNewPicBuf ? uiCWidth * rcFrame.m_cComponent[CHANNEL_TYPE_CHROMA].m_uiBytesPerSample
                                                                                  : rcPicBuf.get(COMPONENT_Cr).stride * rcFrame.m_cComponent[VVC_CT_Y].m_uiBytesPerSample;
         rcFrame.m_cComponent[VVC_CT_V].m_uiByteOffset     = rcFrame.m_cComponent[VVC_CT_U].m_uiByteOffset + nCSize;
+        rcFrame.m_cComponent[VVC_CT_V].m_uiBitDepth       = rcBitDepths.recon[CHANNEL_TYPE_CHROMA];
         if( m_bCreateNewPicBuf )    nBufSize = (rcFrame.m_cComponent[VVC_CT_Y].m_iStride * uiHeight) + (nCSize<<1);
         break;
       }
@@ -1018,6 +1020,7 @@ int VVDecImpl::xCreateFrame( Frame& rcFrame, const CPelUnitBuf& rcPicBuf, uint32
         rcFrame.m_cComponent[VVC_CT_U].m_iStride          = m_bCreateNewPicBuf ? uiCWidth * rcFrame.m_cComponent[CHANNEL_TYPE_CHROMA].m_uiBytesPerSample :
                                                                                    rcPicBuf.get(COMPONENT_Cb).stride * rcFrame.m_cComponent[VVC_CT_Y].m_uiBytesPerSample;
         rcFrame.m_cComponent[VVC_CT_U].m_uiByteOffset     = rcFrame.m_cComponent[VVC_CT_Y].m_iStride * rcFrame.m_cComponent[VVC_CT_Y].m_uiHeight;
+        rcFrame.m_cComponent[VVC_CT_U].m_uiBitDepth       = rcBitDepths.recon[CHANNEL_TYPE_CHROMA];
 
         uint32_t nCSize = rcFrame.m_cComponent[VVC_CT_U].m_iStride*uiCHeight;
 
@@ -1028,6 +1031,7 @@ int VVDecImpl::xCreateFrame( Frame& rcFrame, const CPelUnitBuf& rcPicBuf, uint32
         rcFrame.m_cComponent[VVC_CT_V].m_iStride          = m_bCreateNewPicBuf ? uiCWidth * rcFrame.m_cComponent[CHANNEL_TYPE_CHROMA].m_uiBytesPerSample
                                                                                  : rcPicBuf.get(COMPONENT_Cr).stride * rcFrame.m_cComponent[VVC_CT_Y].m_uiBytesPerSample;
         rcFrame.m_cComponent[VVC_CT_V].m_uiByteOffset     = rcFrame.m_cComponent[VVC_CT_U].m_uiByteOffset + nCSize;
+        rcFrame.m_cComponent[VVC_CT_V].m_uiBitDepth       = rcBitDepths.recon[CHANNEL_TYPE_CHROMA];
 
         if( m_bCreateNewPicBuf )  nBufSize = (rcFrame.m_cComponent[VVC_CT_Y].m_iStride * uiHeight) + (nCSize<<1);
         break;
@@ -1043,6 +1047,7 @@ int VVDecImpl::xCreateFrame( Frame& rcFrame, const CPelUnitBuf& rcPicBuf, uint32
         rcFrame.m_cComponent[VVC_CT_U].m_iStride          = m_bCreateNewPicBuf ? uiWidth * rcFrame.m_cComponent[CHANNEL_TYPE_CHROMA].m_uiBytesPerSample
                                                                                  : rcPicBuf.get(COMPONENT_Cb).stride * rcFrame.m_cComponent[VVC_CT_Y].m_uiBytesPerSample;
         rcFrame.m_cComponent[VVC_CT_U].m_uiByteOffset     = rcFrame.m_cComponent[VVC_CT_Y].m_iStride * rcFrame.m_cComponent[VVC_CT_Y].m_uiHeight;
+        rcFrame.m_cComponent[VVC_CT_U].m_uiBitDepth       = rcBitDepths.recon[CHANNEL_TYPE_CHROMA];
 
         rcFrame.m_cComponent[VVC_CT_V].m_uiWidth          = uiWidth;
         rcFrame.m_cComponent[VVC_CT_V].m_uiHeight         = uiHeight;
@@ -1050,6 +1055,7 @@ int VVDecImpl::xCreateFrame( Frame& rcFrame, const CPelUnitBuf& rcPicBuf, uint32
         rcFrame.m_cComponent[VVC_CT_V].m_iStride          = m_bCreateNewPicBuf ? uiWidth * rcFrame.m_cComponent[CHANNEL_TYPE_CHROMA].m_uiBytesPerSample
                                                                                  : rcPicBuf.get(COMPONENT_Cr).stride * rcFrame.m_cComponent[VVC_CT_Y].m_uiBytesPerSample;
         rcFrame.m_cComponent[VVC_CT_V].m_uiByteOffset     = rcFrame.m_cComponent[VVC_CT_U].m_uiByteOffset<<1;
+        rcFrame.m_cComponent[VVC_CT_V].m_uiBitDepth       = rcBitDepths.recon[CHANNEL_TYPE_CHROMA];
 
         if( m_bCreateNewPicBuf ) nBufSize = (rcFrame.m_cComponent[VVC_CT_Y].m_iStride * uiHeight)*3;
         break;


### PR DESCRIPTION
I added a dynamic library interface which can be easily used to decode vvc bitstreams. E.g. [YUView ](https://github.com/IENT/YUView) uses this interface.

So:
 - Besides the executable, we also compile everything into a dll (windws), so (linux) or dylib (mac)
 - There is no change to any other part of the code. The executable should work as it did before.
 - There is one hack in there for the global variables that are used. Global variables are generally a very bad idea and especially for dynamic libraries they are a huge no-no. This part (the Rom) should be refactored to not use global variables.
 - There also is a small bugfix in here where the bit-depth of the output planes are not set correctly.