### PR TITLE
Use condition variable for threads

### DIFF
--- a/source/Lib/Utilities/NoMallocThreadPool.h
+++ b/source/Lib/Utilities/NoMallocThreadPool.h
@@ -438,6 +438,11 @@ public:
           t.barriers   = std::move( barriers );
           t.state      = WAITING;
 
+          {
+            std::unique_lock<std::mutex> lock(m_workMutex);
+            m_threadCV.notify_all();
+          }
+
 #if ADD_TASK_THREAD_SAFE
           l.lock();
 #endif
@@ -474,8 +479,9 @@ private:
 #if ADD_TASK_THREAD_SAFE
   std::mutex               m_nextFillSlotMutex;
 #endif
-  std::mutex               m_idleMutex;
-  std::atomic_uint         m_waitingThreads{ 0 };
+
+  std::mutex               m_workMutex;
+  std::condition_variable  m_threadCV;
 
   // internal functions
   void         threadProc  ( int threadId );


### PR DESCRIPTION
### Issue
In your original implementation there was no option for all threads to fall asleep. One thread was always active in an infinite loop checking the task list for a new task to do. If the decoder is used as a library, it can happen that the decoder has to wait for data and can not process anything right now. In this case all threads should fall asleep and wait for more data. In YUView for example I do this on purpose (pause the decoder until the user wants to see the next frame). 

### Work
Replaced the mutex based wait with a condition variable that the threads wait on when no work is to-do. Any of the following events will wake up all threads (if sleeping):
 - A new task is added to the task list (`addBarrierTask`)
 - A thread finished its work. This means that blocked work may now be unblocked.
 - On close (so that all threads terminate)

@adamjw24 Did I get the basic concept correct or am I missing something? I also had 2 questions when looking at the code:
 - Is there the possibility that a task is unblocked in the middle of another task running? Because this would currently not wake up the threads and may slow down things.
 - What is the point of the `ChunkedTaskQueue`? Why not use a nowmal `std::vector` with a custom function to do the wrap around iteration? The vector will grow in the same exponential way that your `ChunkedTaskQueue` does.