### PR TITLE
Thread pool pause

### DIFF
--- a/include/vvdec/vvdec.h
+++ b/include/vvdec/vvdec.h
@@ -110,8 +110,8 @@ typedef enum
 }vvdecLogLevel;
 
 /*
-  \enum LogLevel
-  The enum LogLevel enumerates supported log levels/verbosity.
+  \enum SIMD_Extension
+  The enum SIMD_Extension enumerates the supported simd optimizations.
 */
 typedef enum
 {
@@ -256,7 +256,7 @@ typedef struct vvdecAccessUnit
 /* vvdec_accessUnit_alloc:
    Allocates an vvdecAccessUnit instance.
    The returned accessUnit is set to default values.
-   The payload memory must be allocated seperately by using vvdecAccessUnit.
+   The payload memory must be allocated seperately by using vvdec_accessUnit_alloc_payload.
    To free the memory use vvdecAccessUnit_free.
 */
 VVDEC_DECL vvdecAccessUnit* vvdec_accessUnit_alloc();

--- a/source/App/vvdecapp/vvdecapp.cpp
+++ b/source/App/vvdecapp/vvdecapp.cpp
@@ -266,7 +266,7 @@ int main( int argc, char* argv[] )
         }
 
         // call decode
-        
+
         iRet = vvdec_decode( dec, accessUnit, &pcFrame );
         if( bIsSlice )
         {

--- a/source/App/vvdecapp/vvdecapp.cpp
+++ b/source/App/vvdecapp/vvdecapp.cpp
@@ -64,9 +64,6 @@ int writeYUVToFileInterlaced( std::ostream *f, vvdecFrame *topField, vvdecFrame 
 
 void msgFnc( void *, int level, const char* fmt, va_list args )
 {
-  (void)level;
-  (void)fmt;
-  (void)args;
   vfprintf( level == 1 ? stderr : stdout, fmt, args );
 }
 
@@ -269,6 +266,7 @@ int main( int argc, char* argv[] )
         }
 
         // call decode
+        
         iRet = vvdec_decode( dec, accessUnit, &pcFrame );
         if( bIsSlice )
         {

--- a/source/App/vvdecapp/vvdecapp.cpp
+++ b/source/App/vvdecapp/vvdecapp.cpp
@@ -215,8 +215,6 @@ int main( int argc, char* argv[] )
     vvdecNalType eNalTypeSlice = VVC_NAL_UNIT_INVALID;
     bool bMultipleSlices = false;
 
-    unsigned nrAU = 0;
-
     int iRead = 0;
     do
     {
@@ -271,14 +269,6 @@ int main( int argc, char* argv[] )
         }
 
         // call decode
-
-        if (nrAU++ == 30)
-        {
-          std::cout << "Start simulated sleeping";
-          std::this_thread::sleep_for(std::chrono::seconds(5));
-          std::cout << "End simulated sleeping";
-        }
-
         iRet = vvdec_decode( dec, accessUnit, &pcFrame );
         if( bIsSlice )
         {

--- a/source/App/vvdecapp/vvdecapp.cpp
+++ b/source/App/vvdecapp/vvdecapp.cpp
@@ -49,6 +49,7 @@ THE POSSIBILITY OF SUCH DAMAGE.
 #include <fstream>
 #include <string.h>
 #include <chrono>
+#include <thread>
 
 #include "vvdec/vvdec.h"
 #include "vvdec/version.h"
@@ -63,6 +64,9 @@ int writeYUVToFileInterlaced( std::ostream *f, vvdecFrame *topField, vvdecFrame 
 
 void msgFnc( void *, int level, const char* fmt, va_list args )
 {
+  (void)level;
+  (void)fmt;
+  (void)args;
   vfprintf( level == 1 ? stderr : stdout, fmt, args );
 }
 
@@ -211,6 +215,8 @@ int main( int argc, char* argv[] )
     vvdecNalType eNalTypeSlice = VVC_NAL_UNIT_INVALID;
     bool bMultipleSlices = false;
 
+    unsigned nrAU = 0;
+
     int iRead = 0;
     do
     {
@@ -265,6 +271,13 @@ int main( int argc, char* argv[] )
         }
 
         // call decode
+
+        if (nrAU++ == 30)
+        {
+          std::cout << "Start simulated sleeping";
+          std::this_thread::sleep_for(std::chrono::seconds(5));
+          std::cout << "End simulated sleeping";
+        }
 
         iRet = vvdec_decode( dec, accessUnit, &pcFrame );
         if( bIsSlice )
@@ -407,7 +420,7 @@ int main( int argc, char* argv[] )
 
     //std::cout << "flush" << std::endl;
 
-    // flush the encoder
+    // flush the decoder
     bFlushDecoder = true;
     while( bFlushDecoder)
     {

--- a/source/Lib/Utilities/ThreadPool.cpp
+++ b/source/Lib/Utilities/ThreadPool.cpp
@@ -96,6 +96,7 @@ ThreadPool::ThreadPool( int numThreads, const char* threadPoolName )
   , m_threads ( numThreads < 0 ? std::thread::hardware_concurrency() : numThreads )
 {
   int tid = 0;
+  m_poolPause.setNrThreads(m_threads.size());
   for( auto& t: m_threads )
   {
     t = std::thread( &ThreadPool::threadProc, this, tid++ );
@@ -154,6 +155,10 @@ void ThreadPool::shutdown( bool block )
 
 void ThreadPool::waitForThreads()
 {
+  std::cout << "waitForThreads unpause\n";
+  m_poolPause.unpauseIfPaused();
+  std::cout << "waitForThreads\n";
+
   for( auto& t: m_threads )
   {
     if( t.joinable() )
@@ -198,7 +203,6 @@ void ThreadPool::threadProc( int threadId )
         std::unique_lock<std::mutex> l( m_idleMutex, std::defer_lock );
 
         ITT_TASKSTART( itt_domain_thrd, itt_handle_TPspinWait );
-        ScopeIncDecCounter cntr( m_waitingThreads );
 
         const auto startWait = std::chrono::steady_clock::now();
         while( !m_exitThreads )
@@ -209,18 +213,19 @@ void ThreadPool::threadProc( int threadId )
             break;
           }
 
+          //const auto waitingNow = m_waitingThreads.load( std::memory_order_relaxed );
           if( !l.owns_lock()
-              && m_waitingThreads.load( std::memory_order_relaxed ) > 1
               && ( BUSY_WAIT_TIME.count() == 0 || std::chrono::steady_clock::now() - startWait > BUSY_WAIT_TIME )
               && !m_exitThreads )
           {
             ITT_TASKSTART( itt_domain_thrd, itt_handle_TPblocked );
+            ScopeIncDecCounter cntr( m_poolPause.m_waitingForLockThreads );
             l.lock();
             ITT_TASKEND( itt_domain_thrd, itt_handle_TPblocked );
           }
           else
           {
-            std::this_thread::yield();
+            m_poolPause.pauseIfAllOtherThreadsWaiting();
           }
         }
 
@@ -238,6 +243,7 @@ void ThreadPool::threadProc( int threadId )
     }
     catch( TaskException& e )
     {
+      std::cout << "Caught task exception\n";
       handleTaskException( e.m_originalException, e.m_task.done, e.m_task.counter, &e.m_task.state );
     }
     catch( std::exception& e )

--- a/source/Lib/Utilities/ThreadPool.cpp
+++ b/source/Lib/Utilities/ThreadPool.cpp
@@ -221,9 +221,13 @@ void ThreadPool::threadProc( int threadId )
             l.lock();
             ITT_TASKEND( itt_domain_thrd, itt_handle_TPblocked );
           }
-          else
+          else if (std::chrono::steady_clock::now() - startWait > std::chrono::milliseconds(500))
           {
             m_poolPause.pauseIfAllOtherThreadsWaiting();
+          }
+          else
+          {
+            std::this_thread::yield();
           }
         }
 

--- a/source/Lib/Utilities/ThreadPool.cpp
+++ b/source/Lib/Utilities/ThreadPool.cpp
@@ -155,9 +155,7 @@ void ThreadPool::shutdown( bool block )
 
 void ThreadPool::waitForThreads()
 {
-  std::cout << "waitForThreads unpause\n";
   m_poolPause.unpauseIfPaused();
-  std::cout << "waitForThreads\n";
 
   for( auto& t: m_threads )
   {

--- a/source/Lib/Utilities/ThreadPool.cpp
+++ b/source/Lib/Utilities/ThreadPool.cpp
@@ -211,7 +211,6 @@ void ThreadPool::threadProc( int threadId )
             break;
           }
 
-          //const auto waitingNow = m_waitingThreads.load( std::memory_order_relaxed );
           if( !l.owns_lock()
               && ( BUSY_WAIT_TIME.count() == 0 || std::chrono::steady_clock::now() - startWait > BUSY_WAIT_TIME )
               && !m_exitThreads )
@@ -245,7 +244,6 @@ void ThreadPool::threadProc( int threadId )
     }
     catch( TaskException& e )
     {
-      std::cout << "Caught task exception\n";
       handleTaskException( e.m_originalException, e.m_task.done, e.m_task.counter, &e.m_task.state );
     }
     catch( std::exception& e )

--- a/source/Lib/Utilities/ThreadPool.h
+++ b/source/Lib/Utilities/ThreadPool.h
@@ -311,10 +311,7 @@ public:
       // or if the thread pool is closed or destroyed.
       std::unique_lock<std::mutex> lock(m_allThreadsWaitingMutex);
       m_allThreadWaitingMoreWork = true;
-      while (m_allThreadWaitingMoreWork)
-      {
-        m_allThreadsWaitingCV.wait(lock);
-      }
+      m_allThreadsWaitingCV.wait( lock, [=] { return !m_allThreadWaitingMoreWork; } );
     }
   }
   

--- a/source/Lib/Utilities/ThreadPool.h
+++ b/source/Lib/Utilities/ThreadPool.h
@@ -286,7 +286,49 @@ private:
   Barrier                         m_done{ false };
 };
 
+class PoolPause
+{
+public:
+  PoolPause() = default;
+  ~PoolPause() { std::cout << "PoolPuase Destroy\n"; }
+  void setNrThreads(size_t nr) { m_nrThreads = nr; }
+  void unpauseIfPaused()
+  {
+    // All threads may be sleeping. If so, wake up.
+    std::unique_lock<std::mutex> lock(m_allThreadsWaitingMutex);
+    m_allThreadWaitingMoreWork = false;
+    m_allThreadsWaitingCV.notify_all();
+  }
+  void pauseIfAllOtherThreadsWaiting()
+  {
+    if (m_nrThreads == 0)
+      return;
+    auto nrWaiting = m_waitingForLockThreads.load( std::memory_order_relaxed );
+    if (nrWaiting == m_nrThreads - 1)
+    {
+      // All threads are waiting. This (current) threads is the one which locked `l`. All
+      // other threads are waiting in the above condition for `l.lock();`.
+      // The only way how more work for the threads can come in is if addBarrierTask is called 
+      // or if the thread pool is closed or destroyed.
+      std::unique_lock<std::mutex> lock(m_allThreadsWaitingMutex);
+      m_allThreadWaitingMoreWork = true;
+      std::cout << "Pool pause\n";
+      while (m_allThreadWaitingMoreWork)
+      {
+        m_allThreadsWaitingCV.wait(lock);
+      }
+      std::cout << "Pool unpause\n";
+    }
+  }
+  
+  std::atomic_uint         m_waitingForLockThreads{ 0 };
 
+private:
+  std::mutex               m_allThreadsWaitingMutex;
+  std::condition_variable  m_allThreadsWaitingCV;
+  bool                     m_allThreadWaitingMoreWork{ false };
+  size_t m_nrThreads{};
+};
 
 // ---------------------------------------------------------------------------
 // Thread Pool
@@ -438,6 +480,7 @@ public:
           l.lock();
 #endif
           m_nextFillSlot.incWrap();
+          m_poolPause.unpauseIfPaused();
           return true;
         }
       }
@@ -472,10 +515,11 @@ private:
   std::mutex               m_nextFillSlotMutex;
 #endif
   std::mutex               m_idleMutex;
-  std::atomic_uint         m_waitingThreads{ 0 };
 
   std::atomic_bool         m_exceptionFlag{ false };
   std::exception_ptr       m_threadPoolException;
+
+  PoolPause m_poolPause;
 
   // internal functions
   void         threadProc     ( int threadId );
@@ -483,7 +527,7 @@ private:
   TaskIterator findNextTask   ( int threadId, TaskIterator startSearch );
   static bool  processTask    ( int threadId, Slot& task );
   bool         bypassTaskQueue( TaskFunc func, void* param, WaitCounter* counter, Barrier* done, CBarrierVec& barriers, TaskFunc readyCheck );
-  static void handleTaskException( const std::exception_ptr e, Barrier* done, WaitCounter* counter, std::atomic<TaskState>* slot_state );
+  static void  handleTaskException( const std::exception_ptr e, Barrier* done, WaitCounter* counter, std::atomic<TaskState>* slot_state );
 };
 
 }

--- a/source/Lib/Utilities/ThreadPool.h
+++ b/source/Lib/Utilities/ThreadPool.h
@@ -290,7 +290,6 @@ class PoolPause
 {
 public:
   PoolPause() = default;
-  ~PoolPause() { std::cout << "PoolPuase Destroy\n"; }
   void setNrThreads(size_t nr) { m_nrThreads = nr; }
   void unpauseIfPaused()
   {
@@ -312,12 +311,10 @@ public:
       // or if the thread pool is closed or destroyed.
       std::unique_lock<std::mutex> lock(m_allThreadsWaitingMutex);
       m_allThreadWaitingMoreWork = true;
-      std::cout << "Pool pause\n";
       while (m_allThreadWaitingMoreWork)
       {
         m_allThreadsWaitingCV.wait(lock);
       }
-      std::cout << "Pool unpause\n";
     }
   }
   


### PR DESCRIPTION
Hi @K-os ,

so I think I found a way to pause the thread pool without costing any performance. Basically the last running thread is only paused in case all other threads are also waiting and after a certain timeout (pausing the thread pool should just be a last resort in case the library is actually paused).

I compared to the unmodified version and could not observe any performance hit.

Maybe this could be a good starting point.