### PR TITLE
Applying changes for 1.1

### DIFF
--- a/.gitlab-ci-internal.yml
+++ b/.gitlab-ci-internal.yml
@@ -7,9 +7,9 @@ stages:
    script:
       - make disable-lto=1 all
    rules:
-      - if: '$CI_PIPELINE_SOURCE == "web"'  
-      - if: '$CI_PIPELINE_SOURCE == "schedule"'  
-      - if: '$CI_PIPELINE_SOURCE == "merge_request_event"'  
+      - if: '$CI_PIPELINE_SOURCE == "web"'
+      - if: '$CI_PIPELINE_SOURCE == "schedule"'
+      - if: '$CI_PIPELINE_SOURCE == "merge_request_event"'
 
 .build_only_template_full:
    extends: .build_only_template
@@ -27,13 +27,14 @@ stages:
           - cmake/modules/define_bitstream_files.cmake
    variables:
      CTEST_OUTPUT_ON_FAILURE: 1
+     CTEST_PARALLEL_LEVEL: 2
    script:
       - make enable-bitstream-download=1 enable-local-bitstream-download=1 disable-lto=1 all
       - make test
    rules:
-      - if: '$CI_PIPELINE_SOURCE == "web"'  
-      - if: '$CI_PIPELINE_SOURCE == "schedule"'  
-      - if: '$CI_PIPELINE_SOURCE == "merge_request_event"'  
+      - if: '$CI_PIPELINE_SOURCE == "web"'
+      - if: '$CI_PIPELINE_SOURCE == "schedule"'
+      - if: '$CI_PIPELINE_SOURCE == "merge_request_event"'
 
 .build_only_macos_arm64_template:
    extends: .build_only_template

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -10,7 +10,7 @@ if( NOT CMAKE_VERSION VERSION_LESS 3.12.0 )
 endif()
 
 # project name
-project( vvdec VERSION 1.1.0.0 )
+project( vvdec VERSION 1.1.0 )
 
 set( VVDEC_ENABLE_X86_SIMD TRUE )
 set( VVDEC_ENABLE_ARM_SIMD FALSE )

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -10,7 +10,7 @@ if( NOT CMAKE_VERSION VERSION_LESS 3.12.0 )
 endif()
 
 # project name
-project( vvdec VERSION 1.0.1.0 )
+project( vvdec VERSION 1.1.0.0 )
 
 set( VVDEC_ENABLE_X86_SIMD TRUE )
 set( VVDEC_ENABLE_ARM_SIMD FALSE )
@@ -48,7 +48,7 @@ if( VVDEC_ENABLE_ARM_SIMD )
   set( CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -DTARGET_SIMD_ARM" )
   set( CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -DTARGET_SIMD_ARM" )
 endif()
-  
+
 list( APPEND CMAKE_MODULE_PATH "${CMAKE_CURRENT_SOURCE_DIR}/cmake/modules" )
 message( STATUS "CMAKE_MODULE_PATH: updating module path to: ${CMAKE_MODULE_PATH}" )
 
@@ -65,8 +65,8 @@ if( NOT CMAKE_SOURCE_DIR STREQUAL CMAKE_CURRENT_SOURCE_DIR )
   # add subdirectories the superproject asked for
   foreach( subdir IN LISTS ${PROJECT_NAME}_ADD_SUBDIRECTORIES )
     add_subdirectory( ${subdir} )
-  endforeach()  
-  
+  endforeach()
+
   return()
 endif()
 
@@ -293,13 +293,22 @@ endif()
 # enable testing with ctest
 enable_testing()
 
+function( read_bitstream_yuv_md5 BITSTREAM_FILE OUT_MD5_HASH )
+  STRING( REGEX REPLACE "\\.bit$" ".yuv.md5" MD5_FILE ${BITSTREAM_FILE} )
+  file( READ ${MD5_FILE} MD5_HASH LIMIT 32 )
+  string( STRIP "${MD5_HASH}" MD5_HASH )
+  string( TOLOWER "${MD5_HASH}" MD5_HASH )
+  set( ${OUT_MD5_HASH} ${MD5_HASH} PARENT_SCOPE )
+endfunction()
+
 # add tests for bitstreams
 foreach( BITSTREAM IN LISTS BITSTREAM_FILES )
   string( REGEX REPLACE "(.*).zip" "\\1" BITSTREAM_SHORT "${BITSTREAM}" )
   set( BITSTREAM_FILE "${BITSTREAM_INSTALL_DIR_BASE}/${BITSTREAM_SHORT}/${BITSTREAM_SHORT}.bit" )
 
   if( EXISTS ${BITSTREAM_FILE} )
-    add_test( NAME Test:${BITSTREAM_SHORT}.bit COMMAND vvdecapp -b ${BITSTREAM_FILE} -dph )
+    read_bitstream_yuv_md5( ${BITSTREAM_FILE} RX_MD5_HASH )
+    add_test( NAME Test:${BITSTREAM_SHORT}.bit COMMAND vvdecapp -b ${BITSTREAM_FILE} -md5 ${RX_MD5_HASH} )
     set_tests_properties( Test:${BITSTREAM_SHORT}.bit PROPERTIES TIMEOUT 120 )
   else()
     add_test( NAME MISSING:${BITSTREAM_SHORT}.bit COMMAND vvdecapp -b ${BITSTREAM_FILE} -dph )
@@ -314,7 +323,8 @@ foreach( BITSTREAM IN LISTS BITSTREAM_FAULTY_FILES )
   set( BITSTREAM_FILE "${BITSTREAM_INSTALL_DIR_BASE}/${BITSTREAM_SHORT}/${BITSTREAM_SHORT}.bit" )
 
   if( EXISTS ${BITSTREAM_FILE} )
-    add_test( NAME Faulty:${BITSTREAM_SHORT}.bit COMMAND vvdecapp -b ${BITSTREAM_FILE} -dph )
+    read_bitstream_yuv_md5( ${BITSTREAM_FILE} RX_MD5_HASH )
+    add_test( NAME Faulty:${BITSTREAM_SHORT}.bit COMMAND vvdecapp -b ${BITSTREAM_FILE} -dph -md5 ${RX_MD5_HASH} )
     set_tests_properties( Faulty:${BITSTREAM_SHORT}.bit PROPERTIES TIMEOUT 120 )
   else()
     add_test( NAME MISSING:${BITSTREAM_SHORT}.bit COMMAND vvdecapp -b ${BITSTREAM_FILE} -dph )

--- a/cmake/modules/define_bitstream_files.cmake
+++ b/cmake/modules/define_bitstream_files.cmake
@@ -8,282 +8,294 @@ endif()
 
 # put bitstreams from the conformance set that are should be decodable and are working
 list( APPEND BITSTREAM_FILES
-  "10b400_A_Bytedance_2.zip"
-  "10b400_B_Bytedance_2.zip"
-  "10b422_B_Sony_4.zip"
-  "8b400_A_Bytedance_2.zip"
-  "8b400_B_Bytedance_2.zip"
-  "8b420_A_Bytedance_2.zip"
-  "8b420_B_Bytedance_2.zip"
-  "8b422_B_Sony_4.zip"
-  "ACTPIC_A_Huawei_3.zip"
-  "ACTPIC_B_Huawei_3.zip"
-  "ACTPIC_C_Huawei_3.zip"
-  "AFF_A_HUAWEI_2.zip"
-  "AFF_B_HUAWEI_2.zip"
-  "ALF_A_Huawei_3.zip"
-  "ALF_B_Huawei_3.zip"
-  "ALF_C_KDDI_2.zip"
-  "ALF_D_Qualcomm_2.zip"
-  "AMVR_A_HHI_3.zip"
-  "AMVR_B_HHI_3.zip"
-  "APSALF_A_Qualcomm_2.zip"
-  "APSLMCS_A_Dolby_3.zip"
-  "APSLMCS_B_Dolby_3.zip"
-  "APSLMCS_C_Dolby_2.zip"
-  "APSLMCS_D_Dolby_1.zip"
-  "APSLMCS_E_Dolby_1.zip"
-  "APSMULT_A_MediaTek_4.zip"
-  "APSMULT_B_MediaTek_4.zip"
-  "AUD_A_Broadcom_3.zip"
-  "BCW_A_MediaTek_4.zip"
-  "BDOF_A_MediaTek_4.zip"
-  "BDPCM_A_Orange_2.zip"
-  "BOUNDARY_A_Huawei_3.zip"
-  "BUMP_A_LGE_2.zip"
-  "BUMP_B_LGE_2.zip"
-  "BUMP_C_LGE_2.zip"
-  "CCALF_A_Sharp_3.zip"
-  "CCALF_B_Sharp_3.zip"
-  "CCALF_C_Sharp_3.zip"
-  "CCALF_D_Sharp_3.zip"
-  "CCLM_A_KDDI_1.zip"
-  "CIIP_A_MediaTek_4.zip"
-  "CodingToolsSets_A_Tencent_2.zip"
-  "CodingToolsSets_B_Tencent_2.zip"
-  "CodingToolsSets_C_Tencent_2.zip"
-  "CodingToolsSets_D_Tencent_2.zip"
-  "CodingToolsSets_E_Tencent_1.zip"
-  "CROP_A_Panasonic_3.zip"
-  "CROP_B_Panasonic_4.zip"
-  "CST_A_MediaTek_4.zip"
-  "CTU_A_MediaTek_4.zip"
-  "CTU_B_MediaTek_4.zip"
-  "CTU_C_MediaTek_4.zip"
-  "CUBEMAP_A_MediaTek_3.zip"
-  "CUBEMAP_B_MediaTek_3.zip"
-  "CUBEMAP_C_MediaTek_3.zip"
-  "DCI_A_Tencent_3.zip"
-  "DCI_B_Tencent_3.zip"
-  "DEBLOCKING_A_Sharp_3.zip"
-  "DEBLOCKING_B_Sharp_2.zip"
-  "DEBLOCKING_C_Huawei_3.zip"
-  "DEBLOCKING_E_Ericsson_3.zip"
-  "DEBLOCKING_F_Ericsson_2.zip"
-  "DMVR_A_Huawei_3.zip"
-  "DMVR_B_KDDI_3.zip"
-  "DPB_A_Sharplabs_2.zip"
-  "DPB_B_Sharplabs_2.zip"
-  "DQ_A_HHI_3.zip"
-  "DQ_B_HHI_3.zip"
-  "ENT444HIGHTIER_A_Sony_3.zip"
-  "ENT444HIGHTIER_B_Sony_3.zip"
-  "ENT444HIGHTIER_C_Sony_3.zip"
-  "ENT444HIGHTIER_D_Sony_3.zip"
-  "ENT444MAINTIER_A_Sony_3.zip"
-  "ENT444MAINTIER_B_Sony_3.zip"
-  "ENT444MAINTIER_C_Sony_3.zip"
-  "ENT444MAINTIER_D_Sony_3.zip"
-  "ENTHIGHTIER_A_Sony_3.zip"
-  "ENTHIGHTIER_B_Sony_3.zip"
-  "ENTHIGHTIER_C_Sony_3.zip"
-  "ENTHIGHTIER_D_Sony_3.zip"
-  "ENTMAINTIER_A_Sony_3.zip"
-  "ENTMAINTIER_B_Sony_3.zip"
-  "ENTMAINTIER_C_Sony_3.zip"
-  "ENTMAINTIER_D_Sony_3.zip"
-  "ENTROPY_A_Chipsnmedia_2.zip"
-  "ENTROPY_A_Qualcomm_2.zip"
-  "ENTROPY_B_Sharp_2.zip"
-  "ERP_A_MediaTek_3.zip"
-  "FIELD_A_Panasonic_4.zip"
-  "FIELD_B_Panasonic_2.zip"
-  "FILLER_A_Bytedance_1.zip"
-  "GDR_A_ERICSSON_2.zip"
-  "GDR_A_NOKIA_2.zip"
-  "GDR_B_NOKIA_2.zip"
-  "GDR_C_NOKIA_1.zip"
-  "GPM_A_Alibaba_3.zip"
-  "GPM_B_Alibaba_1.zip"
-  "HLG_A_NHK_3.zip"
-  "HLG_B_NHK_3.zip"
-  "HRD_A_Fujitsu_3.zip"
-  "HRD_B_Fujitsu_2.zip"
-  "IBC_A_Tencent_2.zip"
-  "IBC_B_Tencent_2.zip"
-  "IBC_C_Tencent_2.zip"
-  "IBC_D_Tencent_2.zip"
-  "IP_A_Huawei_2.zip"
-  "IP_B_Nokia_1.zip"
-  "ISP_A_HHI_3.zip"
-  "ISP_B_HHI_3.zip"
-  "JCCR_A_Nokia_2.zip"
-  "JCCR_B_Nokia_2.zip"
-  "JCCR_C_HHI_3.zip"
-  "JCCR_D_HHI_3.zip"
-  "JCCR_E_Nokia_1.zip"
-  "JCCR_F_Nokia_1.zip"
-  "LFNST_A_LGE_4.zip"
-  "LFNST_B_LGE_4.zip"
-  "LFNST_C_HHI_3.zip"
-  "LFNST_D_HHI_3.zip"
-  "LMCS_A_Dolby_3.zip"
-  "LMCS_B_Dolby_2.zip"
-  "LMCS_C_Dolby_1.zip"
-  "LOSSLESS_A_HHI_3.zip"
-  "LOSSLESS_B_HHI_3.zip"
-  "LTRP_A_ERICSSON_3.zip"
-  "MERGE_A_Qualcomm_2.zip"
-  "MERGE_B_Qualcomm_2.zip"
-  "MERGE_C_Qualcomm_2.zip"
-  "MERGE_D_Qualcomm_2.zip"
-  "MERGE_E_Qualcomm_2.zip"
-  "MERGE_F_Qualcomm_2.zip"
-  "MERGE_G_Qualcomm_2.zip"
-  "MERGE_H_Qualcomm_2.zip"
-  "MERGE_I_Qualcomm_2.zip"
-  "MERGE_J_Qualcomm_2.zip"
-  "MIP_A_HHI_3.zip"
-  "MIP_B_HHI_3.zip"
-  "MMVD_A_SAMSUNG_3.zip"
-  "MNUT_A_Nokia_3.zip"
-  "MNUT_B_Nokia_2.zip"
-  "MPM_A_LGE_3.zip"
-  "MRLP_A_HHI_2.zip"
-  "MRLP_B_HHI_2.zip"
-  "MTS_A_LGE_4.zip"
-  "MTS_B_LGE_4.zip"
-  "MTS_LFNST_A_LGE_4.zip"
-  "MTS_LFNST_B_LGE_4.zip"
-  "MVCOMP_A_Sharp_2.zip"
-  "PDPC_A_Qualcomm_3.zip"
-  "PDPC_B_Qualcomm_3.zip"
-  "PDPC_C_Qualcomm_2.zip"
-  "PHSH_B_Sharp_1.zip"
-  "PMERGE_A_MediaTek_1.zip"
-  "PMERGE_B_MediaTek_1.zip"
-  "PMERGE_C_MediaTek_1.zip"
-  "PMERGE_D_MediaTek_1.zip"
-  "PMERGE_E_MediaTek_1.zip"
-  "POC_A_Nokia_1.zip"
-  "POUT_A_Sharplabs_2.zip"
-  "PPS_A_Bytedance_1.zip"
-  "PPS_B_Bytedance_1.zip"
-  "PPS_C_Bytedance_1.zip"
-  "PQ_A_Dolby_1.zip"
-  "PROF_A_Interdigital_3.zip"
-  "PROF_B_Interdigital_3.zip"
-  "PSEXT_A_Nokia_2.zip"
-  "PSEXT_B_Nokia_2.zip"
-  "QTBTT_A_MediaTek_4.zip"
-  "QUANT_A_Huawei_2.zip"
-  "QUANT_B_Huawei_2.zip"
-  "QUANT_C_Huawei_2.zip"
-  "QUANT_D_Huawei_4.zip"
-  "RAP_A_HHI_1.zip"
-  "RAP_B_HHI_1.zip"
-  "RAP_C_HHI_1.zip"
-  "RAP_D_HHI_1.zip"
-  "RPL_A_ERICSSON_2.zip"
-  "RPR_A_Alibaba_4.zip"
-  "RPR_B_Alibaba_3.zip"
-  "RPR_C_Alibaba_3.zip"
-  "SAO_A_SAMSUNG_3.zip"
-  "SAO_B_SAMSUNG_3.zip"
-  "SAO_C_SAMSUNG_3.zip"
-  "SBT_A_HUAWEI_2.zip"
-  "SbTMVP_A_Bytedance_3.zip"
-  "SbTMVP_B_Bytedance_3.zip"
-  "SCALING_A_InterDigital_1.zip"
-  "SCALING_B_InterDigital_1.zip"
-  "SCALING_C_InterDigital_1.zip"
-  "SDH_A_Dolby_2.zip"
-  "SLICES_A_HUAWEI_2.zip"
-  "SMVD_A_HUAWEI_2.zip"
-  "SPS_A_Bytedance_1.zip"
-  "SPS_B_Bytedance_1.zip"
-  "SPS_C_Bytedance_1.zip"
-  "SUBPIC_A_HUAWEI_3.zip"
-  "SUBPIC_B_HUAWEI_3.zip"
-  "SUBPIC_C_ERICSSON_1.zip"
-  "SUBPIC_D_MediaTek_1.zip"
-  "SUBPIC_D_ERICSSON_1.zip"
-  "TEMPSCAL_A_Panasonic_4.zip"
-  "TEMPSCAL_B_Panasonic_5.zip"
-  "TEMPSCAL_C_Panasonic_3.zip"
-  "TILE_A_Nokia_2.zip"
-  "TILE_B_Nokia_2.zip"
-  "TILE_C_Nokia_2.zip"
-  "TILE_D_Nokia_2.zip"
-  "TILE_E_Nokia_2.zip"
-  "TILE_F_Nokia_2.zip"
-  "TILE_G_Nokia_2.zip"
-  "TMVP_A_Chipsnmedia_3.zip"
-  "TMVP_B_Chipsnmedia_3.zip"
-  "TMVP_C_Chipsnmedia_3.zip"
-  "TMVP_D_Chipsnmedia_3.zip"
-  "TRANS_A_Chipsnmedia_2.zip"
-  "TRANS_B_Chipsnmedia_2.zip"
-  "TRANS_C_Chipsnmedia_2.zip"
-  "TRANS_D_Chipsnmedia_2.zip"
-  "TREE_A_HHI_3.zip"
-  "TREE_B_HHI_3.zip"
-  "TREE_C_HHI_3.zip"
-  "VIRTUAL_A_MediaTek_3.zip"
-  "VIRTUAL_B_MediaTek_3.zip"
-  "WP_A_InterDigital_3.zip"
-  "WP_B_InterDigital_3.zip"
-  "WPP_A_Sharp_3.zip"
-  "WPP_B_Sharp_2.zip"
-  "WRAP_A_InterDigital_4.zip"
-  "WRAP_B_InterDigital_4.zip"
-  "WRAP_C_InterDigital_4.zip"
-  "WRAP_D_InterDigital_4.zip"
+  10b400_A_Bytedance_2.zip
+  10b400_B_Bytedance_2.zip
+  10b422_B_Sony_4.zip
+  8b400_A_Bytedance_2.zip
+  8b400_B_Bytedance_2.zip
+  8b420_A_Bytedance_2.zip
+  8b420_B_Bytedance_2.zip
+  8b422_B_Sony_4.zip
+  ACTPIC_A_Huawei_3.zip
+  ACTPIC_B_Huawei_3.zip
+  ACTPIC_C_Huawei_3.zip
+  AFF_A_HUAWEI_2.zip
+  AFF_B_HUAWEI_2.zip
+  ALF_A_Huawei_3.zip
+  ALF_B_Huawei_3.zip
+  ALF_C_KDDI_3.zip
+  ALF_D_Qualcomm_2.zip
+  AMVR_A_HHI_3.zip
+  AMVR_B_HHI_3.zip
+  APSALF_A_Qualcomm_2.zip
+  APSLMCS_A_Dolby_3.zip
+  APSLMCS_B_Dolby_3.zip
+  APSLMCS_C_Dolby_2.zip
+  APSLMCS_D_Dolby_1.zip
+  APSLMCS_E_Dolby_1.zip
+  APSMULT_A_MediaTek_4.zip
+  APSMULT_B_MediaTek_4.zip
+  AUD_A_Broadcom_3.zip
+  BCW_A_MediaTek_4.zip
+  BDOF_A_MediaTek_4.zip
+  BDPCM_A_Orange_2.zip
+  BOUNDARY_A_Huawei_3.zip
+  BUMP_A_LGE_2.zip
+  BUMP_B_LGE_2.zip
+  BUMP_C_LGE_2.zip
+  CCALF_A_Sharp_3.zip
+  CCALF_B_Sharp_3.zip
+  CCALF_C_Sharp_3.zip
+  CCALF_D_Sharp_3.zip
+  CCLM_A_KDDI_2.zip
+  CIIP_A_MediaTek_4.zip
+  CodingToolsSets_A_Tencent_2.zip
+  CodingToolsSets_B_Tencent_2.zip
+  CodingToolsSets_C_Tencent_2.zip
+  CodingToolsSets_D_Tencent_2.zip
+  CodingToolsSets_E_Tencent_1.zip
+  CROP_A_Panasonic_3.zip
+  CROP_B_Panasonic_4.zip
+  CST_A_MediaTek_4.zip
+  CTU_A_MediaTek_4.zip
+  CTU_B_MediaTek_4.zip
+  CTU_C_MediaTek_4.zip
+  CUBEMAP_A_MediaTek_3.zip
+  CUBEMAP_B_MediaTek_3.zip
+  CUBEMAP_C_MediaTek_3.zip
+  DCI_A_Tencent_3.zip
+  DCI_B_Tencent_3.zip
+  DEBLOCKING_A_Sharp_3.zip
+  DEBLOCKING_B_Sharp_2.zip
+  DEBLOCKING_C_Huawei_3.zip
+  DEBLOCKING_E_Ericsson_3.zip
+  DEBLOCKING_F_Ericsson_2.zip
+  DMVR_A_Huawei_3.zip
+  DMVR_B_KDDI_4.zip
+  DPB_A_Sharplabs_2.zip
+  DPB_B_Sharplabs_2.zip
+  DQ_A_HHI_3.zip
+  DQ_B_HHI_3.zip
+  ENT444HIGHTIER_A_Sony_3.zip
+  ENT444HIGHTIER_B_Sony_3.zip
+  ENT444HIGHTIER_C_Sony_3.zip
+  ENT444HIGHTIER_D_Sony_3.zip
+  ENT444MAINTIER_A_Sony_3.zip
+  ENT444MAINTIER_B_Sony_3.zip
+  ENT444MAINTIER_C_Sony_3.zip
+  ENT444MAINTIER_D_Sony_3.zip
+  ENTHIGHTIER_A_Sony_3.zip
+  ENTHIGHTIER_B_Sony_3.zip
+  ENTHIGHTIER_C_Sony_3.zip
+  ENTHIGHTIER_D_Sony_3.zip
+  ENTMAINTIER_A_Sony_3.zip
+  ENTMAINTIER_B_Sony_3.zip
+  ENTMAINTIER_C_Sony_3.zip
+  ENTMAINTIER_D_Sony_3.zip
+  ENTROPY_A_Chipsnmedia_2.zip
+  ENTROPY_B_Sharp_2.zip
+  ENTROPY_C_Qualcomm_1.zip
+  ERP_A_MediaTek_3.zip
+  FIELD_A_Panasonic_4.zip
+  FIELD_B_Panasonic_2.zip
+  FILLER_A_Bytedance_1.zip
+  GDR_A_ERICSSON_2.zip
+  GDR_B_NOKIA_2.zip
+  GDR_C_NOKIA_2.zip
+  GDR_D_ERICSSON_1.zip
+  GPM_A_Alibaba_3.zip
+  GPM_B_Alibaba_1.zip
+  HLG_A_NHK_4.zip
+  HLG_B_NHK_4.zip
+  HRD_A_Fujitsu_3.zip
+  HRD_B_Fujitsu_2.zip
+  IBC_A_Tencent_2.zip
+  IBC_B_Tencent_2.zip
+  IBC_C_Tencent_2.zip
+  IBC_D_Tencent_2.zip
+  IP_A_Huawei_2.zip
+  IP_B_Nokia_1.zip
+  ISP_A_HHI_3.zip
+  ISP_B_HHI_3.zip
+  JCCR_A_Nokia_2.zip
+  JCCR_B_Nokia_2.zip
+  JCCR_C_HHI_3.zip
+  JCCR_D_HHI_3.zip
+  JCCR_E_Nokia_1.zip
+  JCCR_F_Nokia_1.zip
+  LFNST_A_LGE_4.zip
+  LFNST_B_LGE_4.zip
+  LFNST_C_HHI_3.zip
+  LFNST_D_HHI_3.zip
+  LMCS_A_Dolby_3.zip
+  LMCS_B_Dolby_2.zip
+  LMCS_C_Dolby_1.zip
+  LOSSLESS_A_HHI_3.zip
+  LOSSLESS_B_HHI_3.zip
+  LTRP_A_ERICSSON_3.zip
+  MERGE_A_Qualcomm_2.zip
+  MERGE_B_Qualcomm_2.zip
+  MERGE_C_Qualcomm_2.zip
+  MERGE_D_Qualcomm_2.zip
+  MERGE_E_Qualcomm_2.zip
+  MERGE_F_Qualcomm_2.zip
+  MERGE_G_Qualcomm_2.zip
+  MERGE_H_Qualcomm_2.zip
+  MERGE_I_Qualcomm_2.zip
+  MERGE_J_Qualcomm_2.zip
+  MIP_A_HHI_3.zip
+  MIP_B_HHI_3.zip
+  MMVD_A_SAMSUNG_3.zip
+  MNUT_A_Nokia_3.zip
+  MNUT_B_Nokia_2.zip
+  MPM_A_LGE_3.zip
+  MRLP_A_HHI_2.zip
+  MRLP_B_HHI_2.zip
+  MTS_A_LGE_4.zip
+  MTS_B_LGE_4.zip
+  MTS_LFNST_A_LGE_4.zip
+  MTS_LFNST_B_LGE_4.zip
+  MVCOMP_A_Sharp_2.zip
+  PDPC_A_Qualcomm_3.zip
+  PDPC_B_Qualcomm_3.zip
+  PDPC_C_Qualcomm_2.zip
+  PHSH_B_Sharp_1.zip
+  PMERGE_A_MediaTek_1.zip
+  PMERGE_B_MediaTek_1.zip
+  PMERGE_C_MediaTek_1.zip
+  PMERGE_D_MediaTek_1.zip
+  PMERGE_E_MediaTek_1.zip
+  POC_A_Nokia_1.zip
+  POUT_A_Sharplabs_2.zip
+  PPS_A_Bytedance_1.zip
+  PPS_B_Bytedance_1.zip
+  PPS_C_Bytedance_1.zip
+  PQ_A_Dolby_1.zip
+  PROF_A_Interdigital_3.zip
+  PROF_B_Interdigital_3.zip
+  PSEXT_A_Nokia_2.zip
+  PSEXT_B_Nokia_2.zip
+  QTBTT_A_MediaTek_4.zip
+  QUANT_A_Huawei_2.zip
+  QUANT_B_Huawei_2.zip
+  QUANT_C_Huawei_2.zip
+  QUANT_D_Huawei_4.zip
+  QUANT_E_Interdigital_1.zip
+  RAP_A_HHI_1.zip
+  RAP_B_HHI_1.zip
+  RAP_C_HHI_1.zip
+  RAP_D_HHI_1.zip
+  RPL_A_ERICSSON_2.zip
+  RPR_A_Alibaba_4.zip
+  RPR_B_Alibaba_3.zip
+  RPR_C_Alibaba_3.zip
+  RPR_D_Qualcomm_1.zip
+  SAO_A_SAMSUNG_3.zip
+  SAO_B_SAMSUNG_3.zip
+  SAO_C_SAMSUNG_3.zip
+  SBT_A_HUAWEI_2.zip
+  SbTMVP_A_Bytedance_3.zip
+  SbTMVP_B_Bytedance_3.zip
+  SCALING_A_InterDigital_1.zip
+  SCALING_B_InterDigital_1.zip
+  SCALING_C_InterDigital_1.zip
+  SDH_A_Dolby_2.zip
+  SLICES_A_HUAWEI_2.zip
+  SMVD_A_HUAWEI_2.zip
+  SPS_A_Bytedance_1.zip
+  SPS_B_Bytedance_1.zip
+  SPS_C_Bytedance_1.zip
+  STILL444_A_KDDI_1.zip
+  STILL444_B_ERICSSON_1.zip
+  STILL_A_KDDI_1.zip
+  STILL_B_ERICSSON_1.zip
+  SUBPIC_A_HUAWEI_3.zip
+  SUBPIC_B_HUAWEI_3.zip
+  SUBPIC_C_ERICSSON_1.zip
+  SUBPIC_D_ERICSSON_1.zip
+  SUBPIC_E_MediaTek_1.zip
+  SUFAPS_A_HHI_1.zip
+  TEMPSCAL_A_Panasonic_4.zip
+  TEMPSCAL_B_Panasonic_5.zip
+  TEMPSCAL_C_Panasonic_3.zip
+  TILE_A_Nokia_2.zip
+  TILE_B_Nokia_2.zip
+  TILE_C_Nokia_2.zip
+  TILE_D_Nokia_2.zip
+  TILE_E_Nokia_2.zip
+  TILE_F_Nokia_2.zip
+  TILE_G_Nokia_2.zip
+  TMVP_A_Chipsnmedia_3.zip
+  TMVP_B_Chipsnmedia_3.zip
+  TMVP_C_Chipsnmedia_3.zip
+  TMVP_D_Chipsnmedia_3.zip
+  TRANS_A_Chipsnmedia_2.zip
+  TRANS_B_Chipsnmedia_2.zip
+  TREE_A_HHI_3.zip
+  TREE_B_HHI_3.zip
+  TREE_C_HHI_3.zip
+  VIRTUAL_A_MediaTek_3.zip
+  VIRTUAL_B_MediaTek_3.zip
+  WP_A_InterDigital_3.zip
+  WP_B_InterDigital_3.zip
+  WPP_A_Sharp_3.zip
+  WPP_B_Sharp_2.zip
+  WRAP_A_InterDigital_4.zip
+  WRAP_B_InterDigital_4.zip
+  WRAP_C_InterDigital_4.zip
+  WRAP_D_InterDigital_4.zip
 )
 
 # put bitstreams from the conformance set that should be decodable but aren't
 list( APPEND BITSTREAM_FAULTY_FILES
+  TRANS_C_Chipsnmedia_2.zip             # probably broken bitstreams. Also does not decode with VTM
+  TRANS_D_Chipsnmedia_2.zip             # probably broken bitstreams. Also does not decode with VTM
 )
 
 # put bitstreams from the conformance set that are not supported (wrong profile/level etc)
 list( APPEND BITSTREAM_NOT_MAIN10_FILES
-  "10b422_A_Sony_4.zip"                               # MAIN_10_444 and MAIN_10_444_STILL_PICTURE is still experimental.
-  "10b422_C_Sony_4.zip"                               # MAIN_10_444 and MAIN_10_444_STILL_PICTURE is still experimental.
-  "10b422_D_Sony_4.zip"                               # MAIN_10_444 and MAIN_10_444_STILL_PICTURE is still experimental.
-  "10b422_E_Sony_4.zip"                               # MAIN_10_444 and MAIN_10_444_STILL_PICTURE is still experimental.
-  "10b422_F_Sony_4.zip"                               # MAIN_10_444 and MAIN_10_444_STILL_PICTURE is still experimental.
-  "10b422_G_Sony_4.zip"                               # palette mode is not yet supported
-  "10b422_H_Sony_4.zip"                               # palette mode is not yet supported
-  "10b422_I_Sony_4.zip"                               # palette mode is not yet supported
-  "10b422_J_Sony_4.zip"                               # palette mode is not yet supported
-  "10b422_K_Sony_4.zip"                               # palette mode is not yet supported
-  "10b422_L_Sony_4.zip"                               # palette mode is not yet supported
-  "8b422_A_Sony_4.zip"                                # MAIN_10_444 and MAIN_10_444_STILL_PICTURE is still experimental.
-  "8b422_C_Sony_4.zip"                                # MAIN_10_444 and MAIN_10_444_STILL_PICTURE is still experimental.
-  "8b422_D_Sony_4.zip"                                # MAIN_10_444 and MAIN_10_444_STILL_PICTURE is still experimental.
-  "8b422_E_Sony_4.zip"                                # MAIN_10_444 and MAIN_10_444_STILL_PICTURE is still experimental.
-  "8b422_F_Sony_4.zip"                                # MAIN_10_444 and MAIN_10_444_STILL_PICTURE is still experimental.
-  "8b422_G_Sony_4.zip"                                # palette mode is not yet supported
-  "8b422_H_Sony_4.zip"                                # palette mode is not yet supported
-  "8b422_I_Sony_4.zip"                                # palette mode is not yet supported
-  "8b422_J_Sony_4.zip"                                # palette mode is not yet supported
-  "8b422_K_Sony_4.zip"                                # palette mode is not yet supported
-  "8b422_L_Sony_4.zip"                                # palette mode is not yet supported
-  "ACT_A_Kwai_2.zip"                                  # palette mode is not yet supported
-  "ILRPL_A_Huawei_2.zip"                              # multi-layer not supported
-  "OLS_A_Tencent_4.zip"                               # TODO ERROR: In function "parseVPS" in ../../source/Lib/DecoderLib/VLCReader.cpp:2053: needs to be adjusted, e.g. sublayer and independent layer stuff -> see VTM-9.0
-  "OLS_B_Tencent_4.zip"                               # TODO ERROR: In function "parseVPS" in ../../source/Lib/DecoderLib/VLCReader.cpp:2053: needs to be adjusted, e.g. sublayer and independent layer stuff -> see VTM-9.0
-  "OLS_C_Tencent_4.zip"                               # TODO ERROR: In function "parseVPS" in ../../source/Lib/DecoderLib/VLCReader.cpp:2053: needs to be adjusted, e.g. sublayer and independent layer stuff -> see VTM-9.0
-  "OPI_A_Nokia_1.zip"                                 # TODO ERROR: In function "parseVPS" in ../../source/Lib/DecoderLib/VLCReader.cpp:2053: needs to be adjusted, e.g. sublayer and independent layer stuff -> see VTM-9.0
-  "OPI_B_Nokia_1.zip"                                 # TODO ERROR: In function "parseVPS" in ../../source/Lib/DecoderLib/VLCReader.cpp:2053: needs to be adjusted, e.g. sublayer and independent layer stuff -> see VTM-9.0
-  "PALETTE_A_Alibaba_2.zip"                           # palette mode is not yet supported
-  "PALETTE_B_Alibaba_2.zip"                           # palette mode is not yet supported
-  "PALETTE_C_Alibaba_2.zip"                           # palette mode is not yet supported
-  "PALETTE_D_Alibaba_2.zip"                           # palette mode is not yet supported
-  "PALETTE_E_Alibaba_1.zip"                           # palette mode is not yet supported
-  "SPALSCAL_A_Qualcomm_3.zip"                         # TODO ERROR: In function "parseVPS" in ../../source/Lib/DecoderLib/VLCReader.cpp:2053: needs to be adjusted, e.g. sublayer and independent layer stuff -> see VTM-9.0
-  "VPS_A_INTEL_3.zip"                                 # TODO ERROR: In function "parseVPS" in ../../source/Lib/DecoderLib/VLCReader.cpp:2053: needs to be adjusted, e.g. sublayer and independent layer stuff -> see VTM-9.0
-  "VPS_B_ERICSSON_1.zip"                              # TODO ERROR: In function "parseVPS" in ../../source/Lib/DecoderLib/VLCReader.cpp:2053: needs to be adjusted, e.g. sublayer and independent layer stuff -> see VTM-9.0
-  "VPS_C_ERICSSON_1.zip"                              # TODO ERROR: In function "parseVPS" in ../../source/Lib/DecoderLib/VLCReader.cpp:2053: needs to be adjusted, e.g. sublayer and independent layer stuff -> see VTM-9.0
+  10b422_A_Sony_4.zip                               # MAIN_10_444 and MAIN_10_444_STILL_PICTURE is still experimental.
+  10b422_C_Sony_4.zip                               # MAIN_10_444 and MAIN_10_444_STILL_PICTURE is still experimental.
+  10b422_D_Sony_4.zip                               # MAIN_10_444 and MAIN_10_444_STILL_PICTURE is still experimental.
+  10b422_E_Sony_4.zip                               # MAIN_10_444 and MAIN_10_444_STILL_PICTURE is still experimental.
+  10b422_F_Sony_4.zip                               # MAIN_10_444 and MAIN_10_444_STILL_PICTURE is still experimental.
+  10b422_G_Sony_4.zip                               # palette mode is not yet supported
+  10b422_H_Sony_4.zip                               # palette mode is not yet supported
+  10b422_I_Sony_4.zip                               # palette mode is not yet supported
+  10b422_J_Sony_4.zip                               # palette mode is not yet supported
+  10b422_K_Sony_4.zip                               # palette mode is not yet supported
+  10b422_L_Sony_4.zip                               # palette mode is not yet supported
+  10b444_A_Kwai_3.zip
+  10b444_B_Kwai_3.zip
+  8b422_A_Sony_4.zip                                # MAIN_10_444 and MAIN_10_444_STILL_PICTURE is still experimental.
+  8b422_C_Sony_4.zip                                # MAIN_10_444 and MAIN_10_444_STILL_PICTURE is still experimental.
+  8b422_D_Sony_4.zip                                # MAIN_10_444 and MAIN_10_444_STILL_PICTURE is still experimental.
+  8b422_E_Sony_4.zip                                # MAIN_10_444 and MAIN_10_444_STILL_PICTURE is still experimental.
+  8b422_F_Sony_4.zip                                # MAIN_10_444 and MAIN_10_444_STILL_PICTURE is still experimental.
+  8b422_G_Sony_4.zip                                # palette mode is not yet supported
+  8b422_H_Sony_4.zip                                # palette mode is not yet supported
+  8b422_I_Sony_4.zip                                # palette mode is not yet supported
+  8b422_J_Sony_4.zip                                # palette mode is not yet supported
+  8b422_K_Sony_4.zip                                # palette mode is not yet supported
+  8b422_L_Sony_4.zip                                # palette mode is not yet supported
+  8b444_A_Kwai_2.zip
+  8b444_B_Kwai_2.zip
+  ACT_A_Kwai_3.zip                                  # palette mode is not yet supported
+  ACT_B_Kwai_3.zip
+  ILRPL_A_Huawei_2.zip                              # multi-layer not supported
+  OLS_A_Tencent_4.zip                               # TODO ERROR: In function "parseVPS" in ../../source/Lib/DecoderLib/VLCReader.cpp:2053: needs to be adjusted, e.g. sublayer and independent layer stuff -> see VTM-9.0
+  OLS_B_Tencent_4.zip                               # TODO ERROR: In function "parseVPS" in ../../source/Lib/DecoderLib/VLCReader.cpp:2053: needs to be adjusted, e.g. sublayer and independent layer stuff -> see VTM-9.0
+  OLS_C_Tencent_4.zip                               # TODO ERROR: In function "parseVPS" in ../../source/Lib/DecoderLib/VLCReader.cpp:2053: needs to be adjusted, e.g. sublayer and independent layer stuff -> see VTM-9.0
+  OPI_A_Nokia_1.zip                                 # TODO ERROR: In function "parseVPS" in ../../source/Lib/DecoderLib/VLCReader.cpp:2053: needs to be adjusted, e.g. sublayer and independent layer stuff -> see VTM-9.0
+  OPI_B_Nokia_2.zip                                 # TODO ERROR: In function "parseVPS" in ../../source/Lib/DecoderLib/VLCReader.cpp:2053: needs to be adjusted, e.g. sublayer and independent layer stuff -> see VTM-9.0
+  PALETTE_A_Alibaba_2.zip                           # palette mode is not yet supported
+  PALETTE_B_Alibaba_2.zip                           # palette mode is not yet supported
+  PALETTE_C_Alibaba_2.zip                           # palette mode is not yet supported
+  PALETTE_D_Alibaba_2.zip                           # palette mode is not yet supported
+  PALETTE_E_Alibaba_2.zip                           # palette mode is not yet supported
+  SPATSCAL444_A_Qualcomm_2.zip
+  SPATSCAL_A_Qualcomm_3.zip                         # TODO ERROR: In function "parseVPS" in ../../source/Lib/DecoderLib/VLCReader.cpp:2053: needs to be adjusted, e.g. sublayer and independent layer stuff -> see VTM-9.0
+  VPS_A_INTEL_3.zip                                 # TODO ERROR: In function "parseVPS" in ../../source/Lib/DecoderLib/VLCReader.cpp:2053: needs to be adjusted, e.g. sublayer and independent layer stuff -> see VTM-9.0
+  VPS_B_ERICSSON_1.zip                              # TODO ERROR: In function "parseVPS" in ../../source/Lib/DecoderLib/VLCReader.cpp:2053: needs to be adjusted, e.g. sublayer and independent layer stuff -> see VTM-9.0
+  VPS_C_ERICSSON_1.zip                              # TODO ERROR: In function "parseVPS" in ../../source/Lib/DecoderLib/VLCReader.cpp:2053: needs to be adjusted, e.g. sublayer and independent layer stuff -> see VTM-9.0
 )
-

--- a/cmake/modules/vvdecInstall.cmake
+++ b/cmake/modules/vvdecInstall.cmake
@@ -76,7 +76,6 @@ install( EXPORT vvdecTargets-release        NAMESPACE vvdec:: FILE vvdecTargets-
 install( EXPORT vvdecTargets-debug          NAMESPACE vvdec:: FILE vvdecTargets-${CONFIG_POSTFIX}.cmake CONFIGURATIONS Debug          DESTINATION ${CMAKE_INSTALL_LIBDIR}/cmake/vvdec )
 install( EXPORT vvdecTargets-relwithdebinfo NAMESPACE vvdec:: FILE vvdecTargets-${CONFIG_POSTFIX}.cmake CONFIGURATIONS RelWithDebInfo DESTINATION ${CMAKE_INSTALL_LIBDIR}/cmake/vvdec )
 
-if( UNIX AND NOT APPLE )
-  configure_file( pkgconfig/libvvdec.pc.in ${CMAKE_CURRENT_BINARY_DIR}/pkgconfig/libvvdec.pc @ONLY )
-  install( FILES ${CMAKE_CURRENT_BINARY_DIR}/pkgconfig/libvvdec.pc DESTINATION ${CMAKE_INSTALL_LIBDIR}/pkgconfig )
-endif()
+configure_file( pkgconfig/libvvdec.pc.in ${CMAKE_CURRENT_BINARY_DIR}/pkgconfig/libvvdec.pc @ONLY )
+install( FILES ${CMAKE_CURRENT_BINARY_DIR}/pkgconfig/libvvdec.pc DESTINATION ${CMAKE_INSTALL_LIBDIR}/pkgconfig )
+

--- a/include/vvdec/vvdec.h
+++ b/include/vvdec/vvdec.h
@@ -259,7 +259,7 @@ typedef struct vvdecAccessUnit
    The payload memory must be allocated seperately by using vvdec_accessUnit_alloc_payload.
    To free the memory use vvdecAccessUnit_free.
 */
-VVDEC_DECL vvdecAccessUnit* vvdec_accessUnit_alloc();
+VVDEC_DECL vvdecAccessUnit* vvdec_accessUnit_alloc( void );
 
 /* vvdec_accessUnit_free:
    release storage of an vvdecAccessUnit instance.
@@ -401,7 +401,7 @@ VVDEC_DECL void vvdec_params_default(vvdecParams *param);
    Allocates an vvdec_params_alloc instance.
    The returned params struct is set to default values.
 */
-VVDEC_DECL vvdecParams* vvdec_params_alloc();
+VVDEC_DECL vvdecParams* vvdec_params_alloc( void );
 
 /* vvdec_params_free:
    release storage of an vvdec_params instance.
@@ -413,7 +413,7 @@ VVDEC_DECL void vvdec_params_free(vvdecParams *params );
   \param[in]  none
   \retval[ ]  const char* version number as string
 */
-VVDEC_DECL const char* vvdec_get_version();
+VVDEC_DECL const char* vvdec_get_version( void );
 
 /* vvdec_decoder_open
   This method initializes the decoder instance.

--- a/source/App/vvdecapp/CMakeLists.txt
+++ b/source/App/vvdecapp/CMakeLists.txt
@@ -23,6 +23,7 @@ target_compile_options( ${EXE_NAME} PRIVATE $<$<OR:$<CXX_COMPILER_ID:Clang>,$<CX
                                             $<$<CXX_COMPILER_ID:GNU>:-Wall -Werror>
                                             $<$<CXX_COMPILER_ID:MSVC>:/W4 /WX /wd4244 /wd4456 >)
 target_link_libraries( ${EXE_NAME} Threads::Threads vvdec )
+target_include_directories( ${EXE_NAME} PRIVATE  ../../Lib/libmd5 )
 
 
 # example: place header files in different folders

--- a/source/App/vvdecapp/CmdLineParser.h
+++ b/source/App/vvdecapp/CmdLineParser.h
@@ -85,7 +85,8 @@ public:
           "\t\t [--parsedelay,-p  <int>    ] : maximal number of frames to read before decoding (default: <= 0 auto detection )\n"
           "\t\t [--simd <int>              ] : used simd extension (0: scalar, 1: sse41, 2: sse42, 3: avx, 4: avx2, 5: avx512) (default: < 0 auto detection)\n"
           "\n"
-          "\t\t [--SEIDecodedPictureHash,-dph ] : enable handling of decoded picture hash SEI messages"
+          "\t\t [--SEIDecodedPictureHash,-dph ] : enable handling of decoded picture hash SEI messages\n"
+          "\t\t [--CheckYuvMD5,-md5 <md5str>  ] : enable calculation of md5 hash over the full YUV output and check against the provided value.\n"
           "\n"
           "\t General Options\n"
           "\n"
@@ -98,7 +99,7 @@ public:
 
 
   static int parse_command_line( int argc, char* argv[] , vvdecParams& rcParams, std::string& rcBitstreamFile, std::string& rcOutputFile,
-                                 int& riFrames, int& riLoops )
+                                 int& riFrames, int& riLoops, std::string& rcExpectYuvMD5 )
   {
     int iRet = 0;
     /* Check command line parameters */
@@ -227,6 +228,21 @@ public:
         if( rcParams.logLevel > VVDEC_VERBOSE )
           fprintf( stdout, "[SEIDecodedPictureHash] : true\n" );
         rcParams.verifyPictureHash = true;
+      }
+      else if( ( !strcmp( (const char*)argv[i_arg], "-md5" ) ) || !strcmp( (const char*)argv[i_arg], "--CheckYuvMD5" ) )
+      {
+        if( i_arg >= argc - 1 ) { fprintf( stderr, " - missing argument for: %s \n", argv[i_arg] ); return -1; }
+        i_arg++;
+        if( strlen( argv[i_arg] ) != 32 )
+        {
+          fprintf( stderr, " - the provided md5 hash to %s should be exactly 32 characters long\n", argv[i_arg - 1] );
+          return -1;
+        }
+
+        rcExpectYuvMD5 = std::string( argv[i_arg++] );
+
+        if( rcParams.logLevel > VVDEC_VERBOSE )
+          fprintf( stdout, "[CheckYuvMD5] : %s\n", rcExpectYuvMD5.c_str() );
       }
       else if( (!strcmp( (const char*)argv[i_arg], "-L" )) || !strcmp( (const char*)argv[i_arg], "--loops" ) )
       {

--- a/source/App/vvdecapp/MD5StreamBuf.h
+++ b/source/App/vvdecapp/MD5StreamBuf.h
@@ -1,0 +1,118 @@
+/* -----------------------------------------------------------------------------
+The copyright in this software is being made available under the BSD
+License, included below. No patent rights, trademark rights and/or
+other Intellectual Property Rights other than the copyrights concerning
+the Software are granted under this license.
+
+For any license concerning other Intellectual Property rights than the software,
+especially patent licenses, a separate Agreement needs to be closed.
+For more information please contact:
+
+Fraunhofer Heinrich Hertz Institute
+Einsteinufer 37
+10587 Berlin, Germany
+www.hhi.fraunhofer.de/vvc
+vvc@hhi.fraunhofer.de
+
+Copyright (c) 2018-2021, Fraunhofer-Gesellschaft zur Förderung der angewandten Forschung e.V.
+All rights reserved.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are met:
+
+ * Redistributions of source code must retain the above copyright notice,
+   this list of conditions and the following disclaimer.
+ * Redistributions in binary form must reproduce the above copyright notice,
+   this list of conditions and the following disclaimer in the documentation
+   and/or other materials provided with the distribution.
+ * Neither the name of Fraunhofer nor the names of its contributors may
+   be used to endorse or promote products derived from this software without
+   specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS
+BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+THE POSSIBILITY OF SUCH DAMAGE.
+
+
+------------------------------------------------------------------------------------------- */
+
+#pragma once
+
+#include "MD5.h"
+
+#include <streambuf>
+#include <array>
+#include <vector>
+
+namespace vvdecoderapp
+{
+
+const int MD5_DIGEST_LENGTH = 128/8;
+
+static inline std::string MD5ToHexString(unsigned char hash[MD5_DIGEST_LENGTH])
+{
+  static const char* hex = "0123456789abcdef";
+  std::string result;
+
+  for(unsigned pos=0; pos < MD5_DIGEST_LENGTH; ++pos)
+  {
+    result += hex[hash[pos] >> 4];
+    result += hex[hash[pos] & 0xf];
+  }
+
+  return result;
+}
+
+class MD5StreamBuf : public std::streambuf
+{
+public:
+  explicit MD5StreamBuf( size_t buf_size = 64 )
+    : m_buffer( buf_size )
+  {
+    std::streambuf::setp( &m_buffer.front(), &m_buffer.back() + 1 );
+  }
+
+  int_type overflow(int_type ch) override
+  {
+    m_md5_ctx.update( (unsigned char*)m_buffer.data(), (unsigned int)m_buffer.size() );
+
+    // reset start & end-pointers
+    std::streambuf::setp( &m_buffer.front(), &m_buffer.back() + 1 );
+    return std::streambuf::sputc(ch);
+  }
+
+  int sync() override
+  {
+    const auto fillLen = std::streambuf::pptr() - std::streambuf::pbase();
+    if( fillLen )
+      m_md5_ctx.update( (unsigned char*)std::streambuf::pbase(), (unsigned int)fillLen );
+    return 0;
+  }
+
+  void finalize(unsigned char digest[16])
+  {
+    sync();
+    m_md5_ctx.finalize( digest);
+  }
+
+  std::string finalizeHex()
+  {
+    unsigned char digest[MD5_DIGEST_LENGTH];
+    finalize(digest);
+    return MD5ToHexString(digest);
+  }
+
+private:
+  vvdec::libmd5::MD5     m_md5_ctx;
+  std::vector<char_type> m_buffer;
+};
+
+}   // namespace vvdecoderapp

--- a/source/App/vvdecapp/vvdecHelper.h
+++ b/source/App/vvdecapp/vvdecHelper.h
@@ -146,7 +146,6 @@ static int _writeComponentToFile( std::ostream *f, vvdecPlane *plane, vvdecPlane
        {
          tmp[x] = p[x];
        }
-
        f->write( (char*)&tmp[0], sizeof(std::vector<short>::value_type)*tmp.size());
        p += plane->stride;
 
@@ -156,7 +155,6 @@ static int _writeComponentToFile( std::ostream *f, vvdecPlane *plane, vvdecPlane
          {
            tmp2[x] = p2[x];
          }
-
          f->write( (char*)&tmp2[0], sizeof(std::vector<short>::value_type)*tmp2.size());
          p2 += planeField2->stride;
        }
@@ -329,12 +327,12 @@ static int readBitstreamFromFile( std::ifstream *f, vvdecAccessUnit* pcAccessUni
   else if (info2 == 1)
     iRewind = -3;
   else
-      printf("readBitstreamFromFile: Error in next start code search \n");
+    fprintf( stderr, "ERR: readBitstreamFromFile: Error in next start code search \n");
 
   f->seekg ( iRewind, f->cur);
   if(f->bad() || f->fail())
   {
-    printf("readBitstreamFromFile: Cannot seek %d in the bit stream file", iRewind );
+    fprintf( stderr, "ERR: readBitstreamFromFile: Cannot seek %d in the bit stream file", iRewind );
     return -1;
   }
 

--- a/source/Lib/CommonLib/CommonDef.h
+++ b/source/Lib/CommonLib/CommonDef.h
@@ -164,11 +164,11 @@ inline int64_t abs (int64_t x) { return _abs64(x); };
 // ====================================================================================================================
 // Common constants
 // ====================================================================================================================
-static const uint64_t   MAX_UINT64 =                  0xFFFFFFFFFFFFFFFFU;
-static const uint32_t   MAX_UINT =                            0xFFFFFFFFU; ///< max. value of unsigned 32-bit integer
-static const int        MAX_INT =                              2147483647; ///< max. value of signed 32-bit integer
-static const uint8_t    MAX_UCHAR =                                   255;
-static const uint8_t    MAX_SCHAR =                                   127;
+static const uint64_t MAX_UINT64 = std::numeric_limits<uint64_t>::max();
+static const uint32_t MAX_UINT   = std::numeric_limits<uint32_t>::max();
+static const int      MAX_INT    = std::numeric_limits<int>     ::max();
+static const uint8_t  MAX_UCHAR  = std::numeric_limits<int8_t>  ::max();
+static const uint8_t  MAX_SCHAR  = std::numeric_limits<uint8_t> ::max();
 
 // ====================================================================================================================
 // Coding tool configuration

--- a/source/Lib/CommonLib/Picture.cpp
+++ b/source/Lib/CommonLib/Picture.cpp
@@ -109,8 +109,6 @@ void Picture::create(const ChromaFormat &_chromaFormat, const Size &size, const 
   m_bufs[PIC_RECONSTRUCTION].create( _chromaFormat, size, _maxCUSize, _margin, MEMORY_ALIGN_DEF_SIZE );
   m_bufs[PIC_RECON_WRAP    ].create( _chromaFormat, size, _maxCUSize, _margin, MEMORY_ALIGN_DEF_SIZE );
   m_bufs[PIC_PREDICTION    ].create( _chromaFormat, size );
-
-  neededForOutput = true;
 }
 
 void Picture::resetForUse()
@@ -125,7 +123,7 @@ void Picture::resetForUse()
   wrapAroundValid  = false;
   wrapAroundOffset = 0;
 #endif
-  neededForOutput  = true;
+  neededForOutput  = false;
   reconstructed    = false;
   inProgress       = false;
   wasLost          = false;

--- a/source/Lib/CommonLib/Picture.h
+++ b/source/Lib/CommonLib/Picture.h
@@ -169,9 +169,7 @@ public:
   bool fieldPic                       = false;
   int  skippedDecCount                = 0;
   int  m_prevQP[MAX_NUM_CHANNEL_TYPE] = { -1, -1 };
-#if JVET_S0124_UNAVAILABLE_REFERENCE
   bool nonReferencePictureFlag        = false;
-#endif
   bool              picCheckedDPH     = false;
   std::vector<bool> subpicsCheckedDPH;
 

--- a/source/Lib/CommonLib/Quant.cpp
+++ b/source/Lib/CommonLib/Quant.cpp
@@ -90,7 +90,7 @@ QpParam::QpParam( const TransformUnit& tu, const ComponentID &compIDX, const boo
     int
     chromaQpOffset  = pps.getQpOffset                    ( jCbCr );
     chromaQpOffset += tu.cu->slice->getSliceChromaQpDelta( jCbCr );
-    chromaQpOffset += pps.getPpsRangeExtension().getChromaQpOffsetListEntry( tu.cu->chromaQpAdj ).u.offset[int( jCbCr ) - 1];
+    chromaQpOffset += pps.getChromaQpOffsetListEntry( tu.cu->chromaQpAdj ).u.offset[int( jCbCr ) - 1];
 
     int qpi = Clip3( -qpBdOffset, MAX_QP, qpy );
     baseQp  = sps.getMappedChromaQpValue( jCbCr, qpi );
@@ -523,7 +523,7 @@ void Quant::setScalingListDec( ScalingList &scalingList )
 #if !JVET_R0166_SCALING_LISTS_CHROMA_444
         if (largerSide == SCALING_LIST_64x64 && list % (SCALING_LIST_NUM / (NUMBER_OF_PREDICTION_MODES)) != 0) continue;
 #endif
-        if (largerSide < SCALING_LIST_4x4) printf("Rectangle Error !\n");
+        CHECK( largerSide < SCALING_LIST_4x4, "Rectangle Error!" );
 #if JVET_R0166_SCALING_LISTS_CHROMA_444
         recScalingListId = g_scalingListId[largerSide][list];
 #else

--- a/source/Lib/CommonLib/Slice.cpp
+++ b/source/Lib/CommonLib/Slice.cpp
@@ -649,7 +649,6 @@ void Slice::checkRPL(const ReferencePictureList* pRPL0, const ReferencePictureLi
 
   int irapPOC = getAssociatedIRAPPOC();
   
-#if JVET_S0124_UNAVAILABLE_REFERENCE
   const int                   numEntries[]       = { pRPL0->getNumberOfShorttermPictures() + pRPL0->getNumberOfLongtermPictures() + pRPL0->getNumberOfInterLayerPictures(),
                                                      pRPL1->getNumberOfShorttermPictures() + pRPL1->getNumberOfLongtermPictures() + pRPL1->getNumberOfInterLayerPictures() };
   const int numActiveEntries[] = { getNumRefIdx( REF_PIC_LIST_0 ), getNumRefIdx( REF_PIC_LIST_1 ) };
@@ -724,216 +723,6 @@ void Slice::checkRPL(const ReferencePictureList* pRPL0, const ReferencePictureLi
 
         CHECK( pcRefPic->layer > m_pcPic->layer, "The picture referred to by each active entry in RefPicList[ 0 ] or RefPicList[ 1 ] shall be present in the DPB and shall have TemporalId less than or equal to that of the current picture." );
       }
-    }
-  }
-#else
-  int numEntriesL0 = pRPL0->getNumberOfShorttermPictures() + pRPL0->getNumberOfLongtermPictures() + pRPL0->getNumberOfInterLayerPictures();
-  int numEntriesL1 = pRPL1->getNumberOfShorttermPictures() + pRPL1->getNumberOfLongtermPictures() + pRPL1->getNumberOfInterLayerPictures();
-
-  int numActiveEntriesL0 = getNumRefIdx(REF_PIC_LIST_0);
-  int numActiveEntriesL1 = getNumRefIdx(REF_PIC_LIST_1);
-
-  bool fieldSeqFlag = getSPS()->getFieldSeqFlag();
-
-  int layerIdx = m_pcPic->cs->vps == nullptr ? 0 : m_pcPic->cs->vps->getGeneralLayerIdx(m_pcPic->layerId);
-
-    if ( m_pcPic->cs->vps && !m_pcPic->cs->vps->getIndependentLayerFlag(layerIdx) && (pRPL0->getNumberOfInterLayerPictures() || pRPL1->getNumberOfInterLayerPictures()))
-  {
-    CHECK( getPicHeader()->getPocMsbPresentFlag(), "The value of ph_poc_msb_cycle_present_flag is required to be equal to 0 when vps_independent_layer_flag[GeneralLayerIdx[nuh_layer_id]] is equal to 0 and there is an ILRP entry in RefPicList[0] or RefPicList[1] of a slice of the current picture" );
-  }
-
-  int currentPictureIsTrailing = 0;
-  if (getPic()->getDecodingOrderNumber() > associatedIRAPDecodingOrderNumber)
-  {
-    switch (m_eNalUnitType)
-    {
-    case NAL_UNIT_CODED_SLICE_STSA:
-    case NAL_UNIT_CODED_SLICE_IDR_W_RADL:
-    case NAL_UNIT_CODED_SLICE_IDR_N_LP:
-    case NAL_UNIT_CODED_SLICE_CRA:
-    case NAL_UNIT_CODED_SLICE_RADL:
-    case NAL_UNIT_CODED_SLICE_RASL:
-      currentPictureIsTrailing = 0;
-      break;
-    default:
-      currentPictureIsTrailing = 1;
-    }
-  }
-
-  for (int i = 0; i < numEntriesL0; i++)
-  {
-    if (!pRPL0->isRefPicLongterm(i))
-    {
-      refPicPOC = getPOC() + pRPL0->getRefPicIdentifier(i);
-      pcRefPic = xGetRefPic(rcListPic, refPicPOC, m_pcPic->layerId);
-    }
-    else
-    {
-      int pocBits = getSPS()->getBitsForPOC();
-      int pocMask = (1 << pocBits) - 1;
-      int ltrpPoc = pRPL0->getRefPicIdentifier(i) & pocMask;
-      if(pRPL0->getDeltaPocMSBPresentFlag(i))
-      {
-        ltrpPoc += getPOC() - pRPL0->getDeltaPocMSBCycleLT(i) * (pocMask + 1) - (getPOC() & pocMask);
-      }
-      pcRefPic = xGetLongTermRefPic(rcListPic, ltrpPoc, pRPL0->getDeltaPocMSBPresentFlag(i), m_pcPic->layerId);
-      refPicPOC = pcRefPic->getPOC();
-    }
-    refPicDecodingOrderNumber = pcRefPic->getDecodingOrderNumber();
-
-    // Checking this: "When the current picture follows an IRAP picture having the same value of nuh_layer_id in both decoding order
-    // and output order, there shall be no picture referred to by an active entry in RefPicList[ 0 ] or RefPicList[ 1 ] that
-    // precedes that IRAP picture in output order or decoding order."
-    if (m_eNalUnitType == NAL_UNIT_CODED_SLICE_CRA || m_eNalUnitType == NAL_UNIT_CODED_SLICE_IDR_W_RADL || m_eNalUnitType == NAL_UNIT_CODED_SLICE_IDR_N_LP )
-    {
-      CHECK(refPicPOC < irapPOC || refPicDecodingOrderNumber < associatedIRAPDecodingOrderNumber, "IRAP picture detected that violate the rule that no entry in RefPicList[] shall precede, in output order or decoding order, any preceding IRAP picture in decoding order (when present).");
-    }
-
-    // Checking this: "When the current picture is a trailing picture that follows in both decoding orderand output order one
-    // or more leading pictures associated with the same IRAP picture, if any, there shall be no picture referred to by an
-    // entry in RefPicList[0] or RefPicList[1] that precedes the associated IRAP picture in output order or decoding order"
-    // Note that when not in field coding, we know that all leading pictures of an IRAP precedes all trailing pictures of the
-    // same IRAP picture.
-    if (currentPictureIsTrailing && !fieldSeqFlag) //
-    {
-      CHECK(refPicPOC < irapPOC || refPicDecodingOrderNumber < associatedIRAPDecodingOrderNumber, "Trailing picture detected that follows one or more leading pictures, if any, and violates the rule that no entry in RefPicList[] shall precede the associated IRAP picture in output order or decoding order.");
-    }
-
-    if (i < numActiveEntriesL0)
-    {
-      // Checking this "When the current picture is a trailing picture, there shall be no picture referred to by an active
-      // entry in RefPicList[ 0 ] or RefPicList[ 1 ] that precedes the associated IRAP picture in output order or decoding order"
-      if (currentPictureIsTrailing)
-      {
-        CHECK(refPicPOC < irapPOC || refPicDecodingOrderNumber < associatedIRAPDecodingOrderNumber, "Trailing picture detected that violate the rule that no active entry in RefPicList[] shall precede the associated IRAP picture in output order or decoding order");
-      }
-
-      // Checking this: "When the current picture is a RADL picture, there shall be no active entry in RefPicList[ 0 ] or
-      // RefPicList[ 1 ] that is any of the following: A picture that precedes the associated IRAP picture in decoding order"
-      if (m_eNalUnitType == NAL_UNIT_CODED_SLICE_RADL)
-      {
-        CHECK(refPicDecodingOrderNumber < associatedIRAPDecodingOrderNumber, "RADL picture detected that violate the rule that no active entry in RefPicList[] shall precede the associated IRAP picture in decoding order");
-      }
-    }
-  }
-
-  for (int i = 0; i < numEntriesL1; i++)
-  {
-    if (!pRPL1->isRefPicLongterm(i))
-    {
-      refPicPOC = getPOC() + pRPL1->getRefPicIdentifier(i);
-      pcRefPic = xGetRefPic(rcListPic, refPicPOC, m_pcPic->layerId);
-    }
-    else
-    {
-      int pocBits = getSPS()->getBitsForPOC();
-      int pocMask = (1 << pocBits) - 1;
-      int ltrpPoc = pRPL1->getRefPicIdentifier(i) & pocMask;
-      if(pRPL1->getDeltaPocMSBPresentFlag(i))
-      {
-        ltrpPoc += getPOC() - pRPL1->getDeltaPocMSBCycleLT(i) * (pocMask + 1) - (getPOC() & pocMask);
-      }
-      pcRefPic = xGetLongTermRefPic(rcListPic, ltrpPoc, pRPL1->getDeltaPocMSBPresentFlag(i), m_pcPic->layerId);
-      refPicPOC = pcRefPic->getPOC();
-    }
-    refPicDecodingOrderNumber = pcRefPic->getDecodingOrderNumber();
-
-    if (m_eNalUnitType == NAL_UNIT_CODED_SLICE_CRA)
-    {
-      CHECK(refPicPOC < irapPOC || refPicDecodingOrderNumber < associatedIRAPDecodingOrderNumber, "CRA picture detected that violate the rule that no entry in RefPicList[] shall precede, in output order or decoding order, any preceding IRAP picture in decoding order (when present).");
-    }
-    if (currentPictureIsTrailing && !fieldSeqFlag)
-    {
-      CHECK(refPicPOC < irapPOC || refPicDecodingOrderNumber < associatedIRAPDecodingOrderNumber, "Trailing picture detected that follows one or more leading pictures, if any, and violates the rule that no entry in RefPicList[] shall precede the associated IRAP picture in output order or decoding order.");
-    }
-
-    if (i < numActiveEntriesL1)
-    {
-      if (currentPictureIsTrailing)
-      {
-        CHECK(refPicPOC < irapPOC || refPicDecodingOrderNumber < associatedIRAPDecodingOrderNumber, "Trailing picture detected that violate the rule that no active entry in RefPicList[] shall precede the associated IRAP picture in output order or decoding order");
-      }
-      if (m_eNalUnitType == NAL_UNIT_CODED_SLICE_RADL)
-      {
-        CHECK(refPicDecodingOrderNumber < associatedIRAPDecodingOrderNumber, "RADL picture detected that violate the rule that no active entry in RefPicList[] shall precede the associated IRAP picture in decoding order");
-      }
-    }
-  }
-#endif
-}
-
-/** Function for marking the reference pictures when an IDR/CRA/CRANT/BLA/BLANT is encountered.
- * \param pocCRA POC of the CRA/CRANT/BLA/BLANT picture
- * \param bRefreshPending flag indicating if a deferred decoding refresh is pending
- * \param rcListPic reference to the reference picture list
- * This function marks the reference pictures as "unused for reference" in the following conditions.
- * If the nal_unit_type is IDR/BLA/BLANT, all pictures in the reference picture list
- * are marked as "unused for reference"
- *    If the nal_unit_type is BLA/BLANT, set the pocCRA to the temporal reference of the current picture.
- * Otherwise
- *    If the bRefreshPending flag is true (a deferred decoding refresh is pending) and the current
- *    temporal reference is greater than the temporal reference of the latest CRA/CRANT/BLA/BLANT picture (pocCRA),
- *    mark all reference pictures except the latest CRA/CRANT/BLA/BLANT picture as "unused for reference" and set
- *    the bRefreshPending flag to false.
- *    If the nal_unit_type is CRA/CRANT, set the bRefreshPending flag to true and pocCRA to the temporal
- *    reference of the current picture.
- * Note that the current picture is already placed in the reference list and its marking is not changed.
- * If the current picture has a nal_ref_idc that is not 0, it will remain marked as "used for reference".
- */
-void Slice::decodingRefreshMarking(int& pocCRA, bool& bRefreshPending, PicList& rcListPic, const bool bEfficientFieldIRAPEnabled)
-{
-  int      pocCurr = getPOC();
-
-  if ( getNalUnitType() == NAL_UNIT_CODED_SLICE_IDR_W_RADL
-    || getNalUnitType() == NAL_UNIT_CODED_SLICE_IDR_N_LP)  // IDR picture
-  {
-    // mark all pictures as not used for reference
-    for( auto & rpcPic: rcListPic )
-    {
-      if (rpcPic->getPOC() != pocCurr)
-      {
-        rpcPic->referenced = false;
-      }
-    }
-    if (bEfficientFieldIRAPEnabled)
-    {
-      bRefreshPending = true;
-    }
-  }
-  else // CRA or No DR
-  {
-    if(bEfficientFieldIRAPEnabled && (getAssociatedIRAPType() == NAL_UNIT_CODED_SLICE_IDR_N_LP || getAssociatedIRAPType() == NAL_UNIT_CODED_SLICE_IDR_W_RADL))
-    {
-      if (bRefreshPending==true && pocCurr > m_iLastIDR) // IDR reference marking pending
-      {
-        for( auto & rpcPic: rcListPic )
-        {
-          if (rpcPic->getPOC() != pocCurr && rpcPic->getPOC() != m_iLastIDR)
-          {
-            rpcPic->referenced = false;
-          }
-        }
-        bRefreshPending = false;
-      }
-    }
-    else
-    {
-      if (bRefreshPending==true && pocCurr > pocCRA) // CRA reference marking pending
-      {
-        for( auto & rpcPic: rcListPic )
-        {
-          if (rpcPic->getPOC() != pocCurr && rpcPic->getPOC() != pocCRA)
-          {
-            rpcPic->referenced = false;
-          }
-        }
-        bRefreshPending = false;
-      }
-    }
-    if ( getNalUnitType() == NAL_UNIT_CODED_SLICE_CRA ) // CRA picture found
-    {
-      bRefreshPending = true;
-      pocCRA = pocCurr;
     }
   }
 }
@@ -1188,12 +977,16 @@ void Slice::checkLeadingPictureRestrictions( const PicListRange & rcListPic ) co
   }
 }
 
-
-int Slice::checkThatAllRefPicsAreAvailable( const PicListRange& rcListPic, const ReferencePictureList *pRPL, bool printErrors, int* missingRefPicIndex, int numActiveRefPics ) const
+bool Slice::checkThatAllRefPicsAreAvailable( const PicListRange&         rcListPic,
+                                             const ReferencePictureList* pRPL,
+                                             int                         numActiveRefPics,
+                                             int*                        missingPOC,
+                                             int*                        missingRefPicIndex ) const
 {
   if( this->isIDR() )
-    return 0;   // Assume that all pic in the DPB will be flushed anyway so no need to check.
+    return true;   // Assume that all pic in the DPB will be flushed anyway so no need to check.
 
+  *missingPOC         = 0;
   *missingRefPicIndex = 0;
 
   // Check long term ref pics
@@ -1236,12 +1029,11 @@ int Slice::checkThatAllRefPicsAreAvailable( const PicListRange& rcListPic, const
 
     if( !isAvailable )
     {
-      if( printErrors )
-      {
-        msg( ERROR, "\nCurrent picture: %d Long-term reference picture with POC = %3d seems to have been removed or not correctly decoded.", this->getPOC(), notPresentPoc );
-      }
+      msg( ERROR, "Current picture: %d Long-term reference picture with POC = %3d seems to have been removed or not correctly decoded.\n", this->getPOC(), notPresentPoc );
+
+      *missingPOC         = notPresentPoc;
       *missingRefPicIndex = ii;
-      return notPresentPoc;
+      return false;
     }
   }
   // report that a picture is lost if it is in the Reference Picture List but not in the DPB
@@ -1266,15 +1058,15 @@ int Slice::checkThatAllRefPicsAreAvailable( const PicListRange& rcListPic, const
     // report that a picture is lost if it is in the Reference Picture List but not in the DPB
     if( !isAvailable && pRPL->getNumberOfShorttermPictures() > 0 )
     {
-      if( printErrors )
-      {
-        msg( ERROR, "\nCurrent picture: %d Short-term reference picture with POC = %3d seems to have been removed or not correctly decoded.", this->getPOC(), notPresentPoc );
-      }
+      msg( ERROR, "Current picture: %d Short-term reference picture with POC = %3d seems to have been removed or not correctly decoded.\n", this->getPOC(), notPresentPoc );
+
+      *missingPOC         = notPresentPoc;
       *missingRefPicIndex = ii;
-      return notPresentPoc;
+      return false;
     }
   }
-  return 0;
+
+  return true;
 }
 
 //! get AC and DC values for weighted pred
@@ -2096,16 +1888,13 @@ void ReferencePictureList::setInterLayerRefPicIdx( int idx, int layerIdc )
 
 void ReferencePictureList::printRefPicInfo() const
 {
-  //DTRACE(g_trace_ctx, D_RPSINFO, "RefPics = { ");
-  printf("RefPics = { ");
+  DTRACE(g_trace_ctx, D_RPSINFO, "RefPics = { ");
   int numRefPic = getNumberOfShorttermPictures() + getNumberOfLongtermPictures();
   for (int ii = 0; ii < numRefPic; ii++)
   {
-    //DTRACE(g_trace_ctx, D_RPSINFO, "%d%s ", m_refPicIdentifier[ii], (m_isLongtermRefPic[ii] == 1) ? "[LT]" : "[ST]");
-    printf("%d%s ", m_refPicIdentifier[ii], (m_isLongtermRefPic[ii] == 1) ? "[LT]" : "[ST]");
+    DTRACE(g_trace_ctx, D_RPSINFO, "%d%s ", m_refPicIdentifier[ii], (m_isLongtermRefPic[ii] == 1) ? "[LT]" : "[ST]");
   }
-  //DTRACE(g_trace_ctx, D_RPSINFO, "}\n");
-  printf("}\n");
+  DTRACE(g_trace_ctx, D_RPSINFO, "}\n");
 }
 
 int ReferencePictureList::calcLTRefPOC( int currPoc, int bitsForPoc, int refPicIdentifier, bool pocMSBPresent, int deltaPocMSBCycle )
@@ -2170,8 +1959,8 @@ void ScalingList::setDefaultScalingList()
  */
 int ScalingList::lengthUvlc(int uiCode)
 {
-  if (uiCode < 0) printf("Error UVLC! \n");
-
+  CHECK( uiCode < 0, "Error UVLC!" )
+  
   int uiLength = 1;
   int uiTemp = ++uiCode;
 

--- a/source/Lib/CommonLib/TypeDef.h
+++ b/source/Lib/CommonLib/TypeDef.h
@@ -125,7 +125,6 @@ namespace vvdec
 #define JVET_S0234_ACT_CRS_FIX                            TBT //to be tested // JVET-S0234: perform chroma residual scaling in RGB domain when ACT is on
 #define JVET_S0123_IDR_UNAVAILABLE_REFERENCE              TBT //to be tested // JVET-S0123: Invoke the generation of unavailable reference picture for an IDR picture that has RPLs.
                                                               //             Change the process for deriving empty RPLs when sps_idr_rpl_present_flag is equal to 0 and nal_unit_type is equal to IDR_W_RADL or IDR_N_LP to involve pps_rpl_info_in_ph_flag.
-#define JVET_S0124_UNAVAILABLE_REFERENCE                  TBT //to be tested // JVET-S0124: Add TemporalId, ph_non_ref_pic_flag, and ph_pic_parameter_set_id for generating unavailable reference pictures
 #define JVET_S0063_VPS_SIGNALLING                         TBT //to be tested // Modifications to VPS signalling - conditionally signal vps_num_ptls_minus1
 #define JVET_S0155_EOS_NALU_CHECK                         TBC // JVET-S0155: Constraints on EOS NAL units
 #define JVET_S0071_SAME_SIZE_SUBPIC_LAYOUT                TBT //to be tested // JVET-S0071 : shortcut when all subpictures have the same size

--- a/source/Lib/DecoderLib/CABACReader.cpp
+++ b/source/Lib/DecoderLib/CABACReader.cpp
@@ -2340,7 +2340,7 @@ void CABACReader::cu_qp_delta( CodingUnit& cu, int predQP, int8_t& qp )
 void CABACReader::cu_chroma_qp_offset( CodingUnit& cu )
 {
   // cu_chroma_qp_offset_flag
-  int       length  = cu.cs->pps->getPpsRangeExtension().getChromaQpOffsetListLen();
+  int       length  = cu.cs->pps->getChromaQpOffsetListLen();
   unsigned  qpAdj   = m_BinDecoder.decodeBin( Ctx::ChromaQpAdjFlag() );
   if( qpAdj && length > 1 )
   {

--- a/source/Lib/DecoderLib/DecLib.cpp
+++ b/source/Lib/DecoderLib/DecLib.cpp
@@ -203,24 +203,10 @@ Picture* DecLib::decode( InputNALUnit& nalu, int* pSkipFrame )
     pcParsedPic = m_decLibParser.parse( nalu, pSkipFrame );
 #endif
   }
-
-  if( m_decLibParser.getPrevPicSkipped() && nalu.m_nalUnitType == NAL_UNIT_CODED_SLICE_GDR )
-  {
-    m_decLibParser.setGdrRecoveryPeriod( true );
-  }
   
   if( pcParsedPic )
   {
     this->decompressPicture( pcParsedPic );
-  }
-
-  if( nalu.isSlice() )
-  {
-    m_decLibParser.setPrevPicSkipped( false );
-  }
-  if( m_decLibParser.getGdrRecoveryPeriod() )
-  {
-    m_picListManager.markNotNeededForOutput();
   }
   
   if( m_decLibParser.getParseNewPicture() &&
@@ -399,7 +385,7 @@ void DecLib::checkPictureHashSEI( Picture* pcPic )
 
   seiMessages pictureHashes = SEI_internal::getSeisByType( pcPic->seiMessageList, VVDEC_DECODED_PICTURE_HASH );
 
-  if( !pictureHashes.empty() && !pcPic->picCheckedDPH )
+  if( !pictureHashes.empty() && !pcPic->picCheckedDPH && pcPic->neededForOutput )
   {
     if( pictureHashes.size() > 1 )
     {
@@ -413,7 +399,7 @@ void DecLib::checkPictureHashSEI( Picture* pcPic )
     pcPic->picCheckedDPH = true;
     msg( INFO, "\n" );
   }
-  else
+  else if( pcPic->neededForOutput )
   {
     if( pcPic->subPictures.empty() )
     {

--- a/source/Lib/DecoderLib/DecLibParser.h
+++ b/source/Lib/DecoderLib/DecLibParser.h
@@ -69,19 +69,13 @@ class PicListManager;
 class DecLibParser
 {
 private:
-  NalUnitType m_associatedIRAPType = NAL_UNIT_INVALID;   ///< NAL unit type of the associated IRAP picture
-  int         m_pocCRA            = 0;                  ///< POC number of the latest CRA picture
-  int         m_pocRandomAccess   = MAX_INT;            ///< POC number of the random access point (the first IDR or CRA picture)
-  int         m_lastRasPoc        = MAX_INT;
-  int         m_associatedIRAPDecodingOrderNumber = 0; ///< Decoding order number of the associated IRAP picture
+  NalUnitType m_associatedIRAPType[MAX_VPS_LAYERS];   ///< NAL unit type of the associated IRAP picture
+  int         m_pocCRA            [MAX_VPS_LAYERS];   ///< POC number of the latest CRA picture
+  int         m_pocRandomAccess      = MAX_INT;       ///< POC number of the random access point (the first IDR or CRA picture)
+  int         m_lastRasPoc           = MAX_INT;
   int         m_decodingOrderCounter = 0;
-  uint32_t    m_prevLayerID       = MAX_INT;
+  uint32_t    m_prevLayerID          = MAX_INT;
 
-  bool        m_prevPicSkipped                = true;
-  bool        m_gdrRecoveryPeriod             = false;
-  int         m_prevGDRInSameLayerPOC         = 0;    ///< POC number of the latest GDR picture
-  int         m_prevGDRInSameLayerRecoveryPOC = 0;    ///< Recovery POC number of the latest GDR picture
-  
   int m_prevPOC                   = MAX_INT;
   int m_prevTid0POC               = 0;
 
@@ -94,9 +88,11 @@ private:
   bool m_bFirstSliceInBitstream   = true;
   bool m_parseNewPicture          = false;
 
-  int  m_lastPOCNoOutputPriorPics = -1;
-  bool m_isNoOutputPriorPics      = false;
-  bool m_lastNoOutputBeforeRecoveryFlag[MAX_VPS_LAYERS] = { false };    //value of variable NoOutputBeforeRecoveryFlag of the assocated CRA/GDR pic
+  int      m_lastPOCNoOutputPriorPics                       = -1;
+  bool     m_isNoOutputPriorPics                            = false;
+  bool     m_lastNoOutputBeforeRecoveryFlag[MAX_VPS_LAYERS] = { false };   // value of variable NoOutputBeforeRecoveryFlag of the assocated CRA/GDR pic
+  int      m_gdrRecoveryPointPocVal        [MAX_VPS_LAYERS];
+  bool     m_gdrRecovered                  [MAX_VPS_LAYERS] = { false };
   uint32_t m_uiSliceSegmentIdx    = 0;
 
   int m_iTargetLayer              = -1;   ///< target stream layer to be decoded
@@ -188,25 +184,16 @@ public:
   void resetPictureUnitNals     ()                      { m_pictureUnitNals.clear(); }
 
   ParameterSetManager getParameterSetManager()          { return m_parameterSetManager; }
-  
-  bool getPrevPicSkipped()                              { return m_prevPicSkipped; }
-  void setPrevPicSkipped( bool val )                    { m_prevPicSkipped = val; }
-  bool getGdrRecoveryPeriod()                           { return m_gdrRecoveryPeriod; }
-  void setGdrRecoveryPeriod( bool val )                 { m_gdrRecoveryPeriod = val; }
-  
+
 private:
   enum SliceHeadResult { SkipPicture, NewPicture, ContinueParsing };
   SliceHeadResult xDecodeSliceHead( InputNALUnit& nalu, int* pSkipFrame );
   Slice*          xDecodeSliceMain( InputNALUnit& nalu );
 
   Picture*        xActivateParameterSets   ( const int layerId );
-  void            prepareLostPicture       ( int iLostPOC, const int layerId );
-#if JVET_S0124_UNAVAILABLE_REFERENCE
+  Picture*        prepareLostPicture       ( int iLostPOC, const int layerId );
   void            prepareUnavailablePicture( const PPS *pps, int iUnavailablePoc, const int layerId, const bool longTermFlag, const int temporalId );
-#else
-  Picture*        prepareUnavailablePicture( int iUnavailablePoc, const int layerId, const bool longTermFlag );
-#endif
-  
+
   void xParsePrefixSEImessages();
   void xParsePrefixSEIsForUnknownVCLNal();
 

--- a/source/Lib/DecoderLib/DecLibRecon.cpp
+++ b/source/Lib/DecoderLib/DecLibRecon.cpp
@@ -586,14 +586,13 @@ Picture* DecLibRecon::waitForPrevDecompressedPic()
   if( m_decodeThreadPool->numThreads() == 0 )
   {
     m_decodeThreadPool->processTasksOnMainThread();
+    CHECK( m_currDecompPic->m_dmvrTaskCounter.isBlocked() || m_currDecompPic->done.isBlocked(), "can't make progress. some dependecy has not been finished" );
   }
   m_currDecompPic->m_dmvrTaskCounter.wait();
   m_currDecompPic->done.wait();
   ITT_TASKEND( itt_domain_dec, itt_handle_waitTasks );
 
-  Picture* pic = m_currDecompPic;
-  m_currDecompPic = nullptr;
-  return pic;
+  return std::exchange( m_currDecompPic, nullptr );
 }
 
 template<bool onlyCheckReadyState>

--- a/source/Lib/Utilities/ThreadPool.cpp
+++ b/source/Lib/Utilities/ThreadPool.cpp
@@ -270,9 +270,8 @@ bool ThreadPool::checkTaskReady( int threadId, CBarrierVec& barriers, ThreadPool
     {
       return false;
     }
+    barriers.clear();
   }
-  // don't clear the barriers, even if they are all unlocked, because exceptions could still be singalled through them
-  // barriers.clear();
 
   if( readyCheck && readyCheck( threadId, taskParam ) == false )
   {

--- a/source/Lib/vvdec/version.h.in
+++ b/source/Lib/vvdec/version.h.in
@@ -1,11 +1,11 @@
 /* -----------------------------------------------------------------------------
 The copyright in this software is being made available under the BSD
-License, included below. No patent rights, trademark rights and/or 
-other Intellectual Property Rights other than the copyrights concerning 
+License, included below. No patent rights, trademark rights and/or
+other Intellectual Property Rights other than the copyrights concerning
 the Software are granted under this license.
 
-For any license concerning other Intellectual Property rights than the software, 
-especially patent licenses, a separate Agreement needs to be closed. 
+For any license concerning other Intellectual Property rights than the software,
+especially patent licenses, a separate Agreement needs to be closed.
 For more information please contact:
 
 Fraunhofer Heinrich Hertz Institute
@@ -14,7 +14,7 @@ Einsteinufer 37
 www.hhi.fraunhofer.de/vvc
 vvc@hhi.fraunhofer.de
 
-Copyright (c) 2018-2021, Fraunhofer-Gesellschaft zur Förderung der angewandten Forschung e.V. 
+Copyright (c) 2018-2021, Fraunhofer-Gesellschaft zur Förderung der angewandten Forschung e.V.
 All rights reserved.
 
 Redistribution and use in source and binary forms, with or without
@@ -46,16 +46,15 @@ THE POSSIBILITY OF SUCH DAMAGE.
 
 #if !defined( VVDEC_VERSION )
 
-#define VVDEC_VERSION "${PROJECT_VERSION_MAJOR}.${PROJECT_VERSION_MINOR}.${PROJECT_VERSION_PATCH}.${PROJECT_VERSION_TWEAK}"
+#define VVDEC_VERSION "${PROJECT_VERSION_MAJOR}.${PROJECT_VERSION_MINOR}.${PROJECT_VERSION_PATCH}"
 
 #define VVDEC_VERSION_MAJOR ${PROJECT_VERSION_MAJOR}
 #define VVDEC_VERSION_MINOR ${PROJECT_VERSION_MINOR}
 #define VVDEC_VERSION_PATCH ${PROJECT_VERSION_PATCH}
-#define VVDEC_VERSION_TWEAK ${PROJECT_VERSION_TWEAK}
 
 #ifdef _WIN32
-#define VVDEC_VS_VERSION      ${PROJECT_VERSION_MAJOR},${PROJECT_VERSION_MINOR},${PROJECT_VERSION_PATCH},${PROJECT_VERSION_TWEAK}
-#define VVDEC_VS_VERSION_STR "${PROJECT_VERSION_MAJOR}.${PROJECT_VERSION_MINOR}.${PROJECT_VERSION_PATCH}.${PROJECT_VERSION_TWEAK}"
+#define VVDEC_VS_VERSION      ${PROJECT_VERSION_MAJOR},${PROJECT_VERSION_MINOR},${PROJECT_VERSION_PATCH}
+#define VVDEC_VS_VERSION_STR "${PROJECT_VERSION_MAJOR}.${PROJECT_VERSION_MINOR}.${PROJECT_VERSION_PATCH}"
 #endif
 
 #endif


### PR DESCRIPTION
* bugfixes (RPL parsing, dQP signaling with tiles, GDR, obsolete pps extension cleanup)
* added decoding to stdout (raw yuv)
* compatibility improvements (mingw compilation, c90, exporting pkgconfig on all systems)
* update supported bitstreams to the current state
* added an option to check the produced YUVs md5 agains a hash from command line (--CheckYuvMD5 option)
* checking the output MD5-sums in the test-suite