### PR TITLE
Xrayleigh2000 develop

### DIFF
--- a/source/Lib/CommonLib/AdaptiveLoopFilter.cpp
+++ b/source/Lib/CommonLib/AdaptiveLoopFilter.cpp
@@ -468,8 +468,8 @@ void AdaptiveLoopFilter::processCTU( CodingStructure & cs, unsigned col, unsigne
 
   const UnitArea ctuArea( getCtuArea( cs, col, line, true ) );
 
-  const unsigned ctuIdx = line * cs.pcv->widthInCtus + col;
-  CtuAlfData currAlfData = cs.picture->getCtuAlfData(ctuIdx);
+  const unsigned ctuIdx  = line * cs.pcv->widthInCtus + col;
+  CtuAlfData currAlfData = cs.getCtuData( col, line ).alfParam;
   currAlfData.alfCtuEnableFlag[1] += currAlfData.ccAlfFilterControl[0] > 0 ? 2 : 0;
   currAlfData.alfCtuEnableFlag[2] += currAlfData.ccAlfFilterControl[1] > 0 ? 2 : 0;
 
@@ -611,8 +611,9 @@ void AdaptiveLoopFilter::filterAreaChromaBothCc( const CPelUnitBuf& srcBuf,
   const int filterIdxCr =
       slice->getTileGroupCcAlfEnabledFlag(COMPONENT_Cr - 1) ? ctuAlfData.ccAlfFilterControl[COMPONENT_Cr - 1] : 0;
   
-  if (filterIdxCb && filterIdxCr) {
-    const Area blk(Position(0, 0), Size(srcBuf.get(COMPONENT_Cb)));
+  if( filterIdxCb && filterIdxCr )
+  {
+    const Area blk( Position( 0, 0 ), Size( srcBuf.get( COMPONENT_Cb ) ) );
     int apsIdxCb = slice->getTileGroupCcAlfCbApsId();
     const int16_t* filterCoeffCb =
         slice->getAlfAPSs()[apsIdxCb]->getCcAlfAPSParam().ccAlfCoeff[COMPONENT_Cb - 1][filterIdxCb - 1];
@@ -622,9 +623,12 @@ void AdaptiveLoopFilter::filterAreaChromaBothCc( const CPelUnitBuf& srcBuf,
 
     m_filterCcAlfBoth( dstBuf.get( COMPONENT_Cb ), dstBuf.get( COMPONENT_Cr ), srcBuf, blkChroma, blkLuma, filterCoeffCb, filterCoeffCr, clpRngs, m_alfVBLumaCTUHeight, m_alfVBLumaPos );
 
-  } else {
-    if (filterIdxCb) {
-      const Area blk(Position(0, 0), Size(srcBuf.get(COMPONENT_Cb)));
+  }
+  else
+  {
+    if( filterIdxCb )
+    {
+      const Area blk( Position( 0, 0 ), Size( srcBuf.get( COMPONENT_Cb ) ) );
       int apsIdx = slice->getTileGroupCcAlfCbApsId();
       const int16_t* filterCoeff =
           slice->getAlfAPSs()[apsIdx]->getCcAlfAPSParam().ccAlfCoeff[COMPONENT_Cb - 1][filterIdxCb - 1];
@@ -632,8 +636,9 @@ void AdaptiveLoopFilter::filterAreaChromaBothCc( const CPelUnitBuf& srcBuf,
       m_filterCcAlf( dstBuf.get( COMPONENT_Cb ), srcBuf, blkChroma, blkLuma, COMPONENT_Cb, filterCoeff, clpRngs, m_alfVBLumaCTUHeight, m_alfVBLumaPos );
     }
 
-    if (filterIdxCr) {
-      const Area blk(Position(0, 0), Size(srcBuf.get(COMPONENT_Cr)));
+    if( filterIdxCr )
+    {
+      const Area blk( Position( 0, 0 ), Size( srcBuf.get( COMPONENT_Cr ) ) );
       int apsIdx = slice->getTileGroupCcAlfCrApsId();
       const int16_t* filterCoeff =
           slice->getAlfAPSs()[apsIdx]->getCcAlfAPSParam().ccAlfCoeff[COMPONENT_Cr - 1][filterIdxCr - 1];
@@ -716,7 +721,7 @@ void AdaptiveLoopFilter::filterCTU( const CPelUnitBuf&     srcBuf,
     }
     
     // has chroma
-    if(numComp > 1)
+    if( numComp > 1 )
     {
       const Area blkLuma  ( Position( 0, 0 ), Size( width, height ) );
       const Area blkChroma( Position( 0, 0 ), Size( srcBuf.get( COMPONENT_Cb ) ) );

--- a/source/Lib/CommonLib/AdaptiveLoopFilter.h
+++ b/source/Lib/CommonLib/AdaptiveLoopFilter.h
@@ -105,6 +105,9 @@ public:
   static void filterBlkCcAlf(const PelBuf &dstBuf, const CPelUnitBuf &recSrc, const Area &blkDst, const Area &blkSrc,
                              const ComponentID compId, const int16_t *filterCoeff, const ClpRngs &clpRngs,
                              int vbCTUHeight, int vbPos);
+  static void filterBlkCcAlfBoth( const PelBuf& dstBufCb, const PelBuf& dstBufCr, const CPelUnitBuf &recSrc, const Area &blkDst,
+                                    const Area &blkSrc, const int16_t* filterCoeffCb, const int16_t* filterCoeffCr,
+                                    const ClpRngs &clpRngs, int vbCTUHeight, int vbPos );
 
   static void prepareCTU    ( CodingStructure &cs, unsigned col, unsigned line );
          void processCTU    ( CodingStructure &cs, unsigned col, unsigned line, int tid = 0, const ChannelType chType = MAX_NUM_CHANNEL_TYPE );
@@ -119,11 +122,16 @@ protected:
 
   void filterCTU                     ( const CPelUnitBuf& srcBuf, const PelUnitBuf& dstBuf, const CtuAlfData& ctuAlfData, const ClpRngs& clpRngs, const ChannelType chType, const CodingStructure& cs, int ctuIdx, Position ctuPos, int tid );
   void filterAreaLuma                ( const CPelUnitBuf& srcBuf, const PelUnitBuf& dstBuf, const Area& blk, const Slice* slice, const APS* const* aps, const short filterSetIndex, const ClpRngs& clpRngs, const int tId );
-  void filterAreaChroma              ( const CPelUnitBuf& srcBuf, const PelUnitBuf& dstBuf, const Area& blkLuma, const Area& blkChroma, const ComponentID compID, const Slice* slice, const APS* const* aps, const int ctuIdx, const CtuAlfData& ctuAlfData, const ClpRngs& clpRngs );
+  void filterAreaChroma              ( const CPelUnitBuf& srcBuf, const PelUnitBuf& dstBuf, const Area& blkChroma, const ComponentID compID, const Slice* slice, const APS* const* aps, const CtuAlfData& ctuAlfData, const ClpRngs& clpRngs );
+  void filterAreaChromaCc            ( const CPelUnitBuf& srcBuf, const PelUnitBuf& dstBuf, const Area& blkLuma, const Area& blkChroma, const ComponentID compID, const Slice* slice, const APS* const* aps, const CtuAlfData& ctuAlfData, const ClpRngs& clpRngs );
+  void filterAreaChromaBothCc        ( const CPelUnitBuf& srcBuf, const PelUnitBuf& dstBuf, const Area& blkLuma, const Area& blkChroma, const Slice* slice, const APS* const* aps, const CtuAlfData& ctuAlfData, const ClpRngs& clpRngs );
 
   template<AlfFilterType filtType>
   static void filterBlk              ( const AlfClassifier *classifier, const PelUnitBuf &recDst, const CPelUnitBuf& recSrc, const Area& blk, const ComponentID compId, const short* filterSet, const short* fClipSet, const ClpRng& clpRng, int vbCTUHeight, int vbPos );
   void ( *m_filterCcAlf )            ( const PelBuf &dstBuf, const CPelUnitBuf &recSrc, const Area &blkDst, const Area &blkSrc, const ComponentID compId, const int16_t *filterCoeff, const ClpRngs &clpRngs, int vbCTUHeight, int vbPos );
+  void ( *m_filterCcAlfBoth )        ( const PelBuf& dstBufCb, const PelBuf& dstBufCr, const CPelUnitBuf &recSrc, const Area &blkDst,
+                                      const Area &blkSrc, const int16_t* filterCoeffCb, const int16_t* filterCoeffCr,
+                                      const ClpRngs &clpRngs, int vbCTUHeight, int vbPos );
 
   void ( *m_filter5x5Blk )           ( const AlfClassifier *classifier, const PelUnitBuf &recDst, const CPelUnitBuf& recSrc, const Area& blk, const ComponentID compId, const short* filterSet, const short* fClipSet, const ClpRng& clpRng, int vbCTUHeight, int vbPos );
   void ( *m_filter7x7Blk )           ( const AlfClassifier *classifier, const PelUnitBuf &recDst, const CPelUnitBuf& recSrc, const Area& blk, const ComponentID compId, const short* filterSet, const short* fClipSet, const ClpRng& clpRng, int vbCTUHeight, int vbPos );

--- a/source/Lib/CommonLib/AdaptiveLoopFilter.h
+++ b/source/Lib/CommonLib/AdaptiveLoopFilter.h
@@ -117,9 +117,9 @@ protected:
   static void deriveClassificationBlk( AlfClassifier *classifier, const CPelBuf& srcLuma, const Area& blk, const int shift, int vbCTUHeight, int vbPos );
   void ( *m_deriveClassificationBlk )( AlfClassifier *classifier, const CPelBuf& srcLuma, const Area& blk, const int shift, int vbCTUHeight, int vbPos );
 
-  void filterCTU                     ( const CPelUnitBuf& srcBuf, const PelUnitBuf& dstBuf, const uint8_t ctuEnableFlag[3], const uint8_t ctuAlternativeData[2], const ClpRngs& clpRngs, const ChannelType chType, const CodingStructure& cs, int ctuIdx, Position ctuPos, int tid );
+  void filterCTU                     ( const CPelUnitBuf& srcBuf, const PelUnitBuf& dstBuf, const CtuAlfData& ctuAlfData, const ClpRngs& clpRngs, const ChannelType chType, const CodingStructure& cs, int ctuIdx, Position ctuPos, int tid );
   void filterAreaLuma                ( const CPelUnitBuf& srcBuf, const PelUnitBuf& dstBuf, const Area& blk, const Slice* slice, const APS* const* aps, const short filterSetIndex, const ClpRngs& clpRngs, const int tId );
-  void filterAreaChroma              ( const CPelUnitBuf& srcBuf, const PelUnitBuf& dstBuf, const Area& blkLuma, const Area& blkChroma, const ComponentID compID, const Slice* slice, const APS* const* aps, const int ctuIdx, const uint8_t ctuComponentEnableFlag, const uint8_t ctuAlternativeData[2], const ClpRngs& clpRngs );
+  void filterAreaChroma              ( const CPelUnitBuf& srcBuf, const PelUnitBuf& dstBuf, const Area& blkLuma, const Area& blkChroma, const ComponentID compID, const Slice* slice, const APS* const* aps, const int ctuIdx, const CtuAlfData& ctuAlfData, const ClpRngs& clpRngs );
 
   template<AlfFilterType filtType>
   static void filterBlk              ( const AlfClassifier *classifier, const PelUnitBuf &recDst, const CPelUnitBuf& recSrc, const Area& blk, const ComponentID compId, const short* filterSet, const short* fClipSet, const ClpRng& clpRng, int vbCTUHeight, int vbPos );

--- a/source/Lib/CommonLib/CodingStructure.h
+++ b/source/Lib/CommonLib/CodingStructure.h
@@ -94,6 +94,21 @@ struct CtuData
   ColocatedMotionInfo*  colMotion;
 };
 
+struct CtuAlfData
+{
+  uint8_t ccAlfFilterControl[2];
+  uint8_t alfCtuEnableFlag[MAX_NUM_COMPONENT];
+  uint8_t alfCtuAlternative[MAX_NUM_COMPONENT-1];
+  short alfCtbFilterIndex;
+  CtuAlfData()
+  {
+    ccAlfFilterControl[0] = ccAlfFilterControl[1] = 0;
+    alfCtuEnableFlag[0] = alfCtuEnableFlag[1] = alfCtuEnableFlag[2] = 0;
+    alfCtuAlternative[0] = alfCtuAlternative[1] = 0;
+    alfCtbFilterIndex = 0;
+  }
+};
+
 // ---------------------------------------------------------------------------
 // coding structure
 // ---------------------------------------------------------------------------

--- a/source/Lib/CommonLib/CodingStructure.h
+++ b/source/Lib/CommonLib/CodingStructure.h
@@ -74,9 +74,21 @@ enum PictureType
 // num collocated motion
 #define NUM_COMOT_IN_CTU ( MAX_CU_SIZE * MAX_CU_SIZE ) >> ( ( MIN_CU_LOG2 + 1 ) << 1 )
 
+
+struct CtuAlfData
+{
+  uint8_t ccAlfFilterControl[MAX_NUM_COMPONENT - 1];
+  uint8_t alfCtuEnableFlag  [MAX_NUM_COMPONENT];
+  uint8_t alfCtuAlternative [MAX_NUM_COMPONENT - 1];
+  short   alfCtbFilterIndex;
+
+  CtuAlfData() : ccAlfFilterControl{ 0, 0 }, alfCtuEnableFlag{ 0, 0, 0 } {}
+};
+
 struct CtuData
 {
   SAOBlkParam           saoParam;
+  CtuAlfData            alfParam;
   const Slice*          slice;
   const PPS*            pps;
   const SPS*            sps;
@@ -93,22 +105,6 @@ struct CtuData
   MotionInfo*           motion;
   ColocatedMotionInfo*  colMotion;
 };
-
-struct CtuAlfData
-{
-  uint8_t ccAlfFilterControl[2];
-  uint8_t alfCtuEnableFlag[MAX_NUM_COMPONENT];
-  uint8_t alfCtuAlternative[MAX_NUM_COMPONENT-1];
-  short alfCtbFilterIndex;
-  CtuAlfData()
-  {
-    ccAlfFilterControl[0] = ccAlfFilterControl[1] = 0;
-    alfCtuEnableFlag[0] = alfCtuEnableFlag[1] = alfCtuEnableFlag[2] = 0;
-    alfCtuAlternative[0] = alfCtuAlternative[1] = 0;
-    alfCtbFilterIndex = 0;
-  }
-};
-
 // ---------------------------------------------------------------------------
 // coding structure
 // ---------------------------------------------------------------------------

--- a/source/Lib/CommonLib/LoopFilter.h
+++ b/source/Lib/CommonLib/LoopFilter.h
@@ -118,8 +118,6 @@ public:
   ~LoopFilter();
 
   /// picture-level deblocking filter
-  void loopFilterPic              ( CodingStructure& cs ) const;
-  void loopFilterPicLine          ( CodingStructure& cs, const ChannelType chType,                   const int ctuLine, const int offset = 0, DeblockEdgeDir edgeDir = NUM_EDGE_DIR ) const;
   void loopFilterCTU              ( CodingStructure& cs, const ChannelType chType, const int ctuCol, const int ctuLine, const int offset = 0, DeblockEdgeDir edgeDir = NUM_EDGE_DIR ) const;
   void calcFilterStrengthsCTU     ( CodingStructure& cs, const int ctuRsAddr );
 };

--- a/source/Lib/CommonLib/Picture.h
+++ b/source/Lib/CommonLib/Picture.h
@@ -235,19 +235,6 @@ public:
 #endif
 
 public:
-  std::vector<CtuAlfData> m_ctuAlfData;
-  CtuAlfData& getCtuAlfData(int ctuAddr)
-  {
-    return m_ctuAlfData[ctuAddr];
-  }
-  const CtuAlfData& getCtuAlfData(int ctuAddr) const
-  {
-    return m_ctuAlfData[ctuAddr];
-  }
-  void resizeCtuAlfData(int numEntries)
-  {
-    m_ctuAlfData.resize(numEntries);
-  }
 
 #if  ENABLE_SIMD_OPT_PICTURE && defined( TARGET_SIMD_X86 )
   void initPictureX86();

--- a/source/Lib/CommonLib/Picture.h
+++ b/source/Lib/CommonLib/Picture.h
@@ -235,51 +235,18 @@ public:
 #endif
 
 public:
-  std::vector<uint8_t>  m_ccAlfFilterControl[2];
-        uint8_t*        getccAlfFilterControl( int compIdx )       { return m_ccAlfFilterControl[compIdx].data(); }
-  const uint8_t*        getccAlfFilterControl( int compIdx ) const { return m_ccAlfFilterControl[compIdx].data(); }
-  std::vector<uint8_t>* getccAlfFilterControl()                    { return m_ccAlfFilterControl; }
-  void                  resizeccAlfFilterControl( int numEntries )
+  std::vector<CtuAlfData> m_ctuAlfData;
+  CtuAlfData& getCtuAlfData(int ctuAddr)
   {
-    for( int compIdx = 0; compIdx < 2; compIdx++ )
-    {
-      m_ccAlfFilterControl[compIdx].resize( numEntries );
-      m_ccAlfFilterControl[compIdx].assign( numEntries, 0 );
-    }
+    return m_ctuAlfData[ctuAddr];
   }
-
-  std::vector<uint8_t>  m_alfCtuEnableFlag[MAX_NUM_COMPONENT];
-  uint8_t*              getAlfCtuEnableFlag( int compIdx ) { return m_alfCtuEnableFlag[compIdx].data(); }
-  std::vector<uint8_t>* getAlfCtuEnableFlag()              { return m_alfCtuEnableFlag; }
-  void                  resizeAlfCtuEnableFlag( int numEntries )
+  const CtuAlfData& getCtuAlfData(int ctuAddr) const
   {
-    for( int compIdx = 0; compIdx < MAX_NUM_COMPONENT; compIdx++ )
-    {
-      m_alfCtuEnableFlag[compIdx].resize( numEntries );
-      m_alfCtuEnableFlag[compIdx].assign( numEntries, 0 );
-    }
+    return m_ctuAlfData[ctuAddr];
   }
-
-  std::vector<short>  m_alfCtbFilterIndex;
-        short*        getAlfCtbFilterIndex()       { return m_alfCtbFilterIndex.data(); }
-  const short*        getAlfCtbFilterIndex() const { return m_alfCtbFilterIndex.data(); }
-  std::vector<short>& getAlfCtbFilterIndexVec() { return m_alfCtbFilterIndex; }
-  void                resizeAlfCtbFilterIndex( int numEntries )
+  void resizeCtuAlfData(int numEntries)
   {
-    m_alfCtbFilterIndex.resize( numEntries );
-    m_alfCtbFilterIndex.assign( numEntries, 0 );
-  }
-
-  std::vector<uint8_t>  m_alfCtuAlternative[MAX_NUM_COMPONENT-1];
-  uint8_t*              getAlfCtuAlternativeData( int compIdx ) { return m_alfCtuAlternative[compIdx].data(); }
-  std::vector<uint8_t>* getAlfCtuAlternative()                 { return m_alfCtuAlternative; }
-  void resizeAlfCtuAlternative( int numEntries )
-  {
-    for( int compIdx = 0; compIdx < MAX_NUM_COMPONENT-1; compIdx++ )
-    {
-      m_alfCtuAlternative[compIdx].resize( numEntries );
-      m_alfCtuAlternative[compIdx].assign( numEntries, 0 );
-    }
+    m_ctuAlfData.resize(numEntries);
   }
 
 #if  ENABLE_SIMD_OPT_PICTURE && defined( TARGET_SIMD_X86 )

--- a/source/Lib/DecoderLib/CABACReader.cpp
+++ b/source/Lib/DecoderLib/CABACReader.cpp
@@ -145,68 +145,7 @@ bool CABACReader::coding_tree_unit( CodingStructure& cs, Slice* slice, const Uni
 
   sao( cs, ctuRsAddr );
 
-  if( m_slice->getTileGroupAlfEnabledFlag( COMPONENT_Y ) )
-  {
-    const PreCalcValues& pcv                = *cs.pcv;
-    int                 frame_width_in_ctus = pcv.widthInCtus;
-    int                 ry                  = ctuRsAddr / frame_width_in_ctus;
-    int                 rx                  = ctuRsAddr - ry * frame_width_in_ctus;
-    const Position      pos( rx * cs.pcv->maxCUWidth, ry * cs.pcv->maxCUHeight );
-    bool                leftAvail  = cs.getCURestricted( pos.offset( -1, 0 ), pos, partitioner.currSliceIdx, partitioner.currTileIdx, CH_L ) ? true : false;
-    bool                aboveAvail = cs.getCURestricted( pos.offset( 0, -1 ), pos, partitioner.currSliceIdx, partitioner.currTileIdx, CH_L ) ? true : false;
-  
-    int leftCTUAddr  = leftAvail  ? ctuRsAddr - 1 : -1;
-    int aboveCTUAddr = aboveAvail ? ctuRsAddr - frame_width_in_ctus : -1;
-  
-    for( int compIdx = 0; compIdx < MAX_NUM_COMPONENT; compIdx++ )
-    {
-      if( m_slice->getTileGroupAlfEnabledFlag( ( ComponentID ) compIdx ) )
-      {
-        uint8_t* ctbAlfFlag = m_slice->getPic()->getAlfCtuEnableFlag( compIdx );
-        int ctx = 0;
-        ctx += leftCTUAddr  > -1 ? ( ctbAlfFlag[leftCTUAddr]  ? 1 : 0 ) : 0;
-        ctx += aboveCTUAddr > -1 ? ( ctbAlfFlag[aboveCTUAddr] ? 1 : 0 ) : 0;
-  
-        ctbAlfFlag[ctuRsAddr] = m_BinDecoder.decodeBin( Ctx::ctbAlfFlag( compIdx * 3 + ctx ) );
-  
-        if( isLuma( ( ComponentID ) compIdx ) && ctbAlfFlag[ctuRsAddr] )
-        {
-          readAlfCtuFilterIndex( cs, ctuRsAddr );
-        }
-
-        if( isChroma( ( ComponentID ) compIdx ) )
-        {
-          const int apsIdx                  = m_slice->getTileGroupApsIdChroma();
-          CHECK( m_slice->getAlfAPSs()[apsIdx] == nullptr, "APS not initialized" );
-          const AlfSliceParam& alfParam     = m_slice->getAlfAPSs()[apsIdx]->getAlfAPSParam();
-          const int numAlts                 = alfParam.numAlternativesChroma;
-          uint8_t* ctbAlfAlternative        = m_slice->getPic()->getAlfCtuAlternativeData( compIdx-1 );
-          ctbAlfAlternative[ctuRsAddr]      = 0;
-
-          if( ctbAlfFlag[ctuRsAddr] )
-          {
-            uint8_t decoded = 0;
-            while( decoded < numAlts - 1 && m_BinDecoder.decodeBin( Ctx::ctbAlfAlternative( compIdx - 1 ) ) )
-              ++decoded;
-            ctbAlfAlternative[ctuRsAddr] = decoded;
-          }
-        }
-      }
-    }
-  }
-
-  for( int compIdx = 1; compIdx < getNumberValidComponents( cs.pcv->chrFormat ); compIdx++ )
-  {
-    if( m_slice->getTileGroupCcAlfEnabledFlag( compIdx - 1 ) )
-    {
-      const int apsIdx        = compIdx == 1 ? m_slice->getTileGroupCcAlfCbApsId() : m_slice->getTileGroupCcAlfCrApsId();
-      const int filterCount   = m_slice->getAlfAPSs()[apsIdx]->getCcAlfAPSParam().ccAlfFilterCount[compIdx - 1];
-  
-      const Position lumaPos  = area.lumaPos();
-  
-      ccAlfFilterControlIdc( cs, ComponentID(compIdx), ctuRsAddr, m_slice->getPic()->getccAlfFilterControl( compIdx - 1 ), lumaPos, filterCount );
-    }
-  }
+  readAlf(cs, ctuRsAddr, partitioner);
 
   bool isLast = false;
 
@@ -282,9 +221,8 @@ bool CABACReader::dt_implicit_qt_split( CodingStructure& cs, Partitioner& partit
   return isLast;
 }
 
-void CABACReader::readAlfCtuFilterIndex( CodingStructure& cs, unsigned ctuRsAddr )
+short CABACReader::readAlfCtuFilterIndex2( CodingStructure& cs, unsigned ctuRsAddr )
 {
-  short* alfCtbFilterSetIndex         = m_slice->getPic()->getAlfCtbFilterIndex();
   const unsigned numAps               = m_slice->getTileGroupNumAps();
   const unsigned numAvailableFiltSets = numAps + NUM_FIXED_FILTER_SETS;
   uint32_t filtIndex = 0;
@@ -306,41 +244,7 @@ void CABACReader::readAlfCtuFilterIndex( CodingStructure& cs, unsigned ctuRsAddr
     xReadTruncBinCode( filtIndex, NUM_FIXED_FILTER_SETS );
   }
 
-  alfCtbFilterSetIndex[ctuRsAddr] = filtIndex;
-}
-
-void CABACReader::ccAlfFilterControlIdc(CodingStructure &cs, const ComponentID compID, const int curIdx, uint8_t *filterControlIdc, Position lumaPos, int filterCount)
-{
-  Position       leftLumaPos    = lumaPos.offset(-(int)cs.pcv->maxCUWidth, 0);
-  Position       aboveLumaPos   = lumaPos.offset(0, -(int)cs.pcv->maxCUWidth);
-  const uint32_t curSliceIdx    = m_slice->getIndependentSliceIdx();
-  const uint32_t curTileIdx     = cs.pps->getTileIdx( lumaPos );
-  bool           leftAvail      = cs.getCURestricted( leftLumaPos,  lumaPos, curSliceIdx, curTileIdx, CH_L ) ? true : false;
-  bool           aboveAvail     = cs.getCURestricted( aboveLumaPos, lumaPos, curSliceIdx, curTileIdx, CH_L ) ? true : false;
-  int            ctxt           = 0;
-
-  if (leftAvail)
-  {
-    ctxt += ( filterControlIdc[curIdx - 1] ) ? 1 : 0;
-  }
-  if (aboveAvail)
-  {
-    ctxt += ( filterControlIdc[curIdx - cs.pcv->widthInCtus] ) ? 1 : 0;
-  }
-  ctxt += ( compID == COMPONENT_Cr ) ? 3 : 0;
-
-  int idcVal  = m_BinDecoder.decodeBin( Ctx::CcAlfFilterControlFlag( ctxt ) );
-  if ( idcVal )
-  {
-    while ( ( idcVal != filterCount ) && m_BinDecoder.decodeBinEP() )
-    {
-      idcVal++;
-    }
-  }
-  filterControlIdc[curIdx] = idcVal;
-
-  DTRACE(g_trace_ctx, D_SYNTAX, "ccAlfFilterControlIdc() compID=%d pos=(%d,%d) ctxt=%d, filterCount=%d, idcVal=%d\n",
-         compID, lumaPos.x, lumaPos.y, ctxt, filterCount, idcVal);
+  return filtIndex;
 }
 
 //================================================================================
@@ -488,8 +392,87 @@ void CABACReader::sao( CodingStructure& cs, unsigned ctuRsAddr )
   }
 }
 
+//================================================================================
+//    void  readAlf( cs, ctuRsAddr, partitioner )
+//================================================================================
+void CABACReader::readAlf(CodingStructure &cs, unsigned int ctuRsAddr, const Partitioner& partitioner)
+{
+    const PreCalcValues& pcv                = *cs.pcv;
+    int                 frame_width_in_ctus = pcv.widthInCtus;
+    int                 ry                  = ctuRsAddr / frame_width_in_ctus;
+    int                 rx                  = ctuRsAddr - ry * frame_width_in_ctus;
+    const Position      pos( rx * cs.pcv->maxCUWidth, ry * cs.pcv->maxCUHeight );
+    bool                leftAvail  = cs.getCURestricted( pos.offset( -1, 0 ), pos, partitioner.currSliceIdx, partitioner.currTileIdx, CH_L ) ? true : false;
+    bool                aboveAvail = cs.getCURestricted( pos.offset( 0, -1 ), pos, partitioner.currSliceIdx, partitioner.currTileIdx, CH_L ) ? true : false;
+  
+    int leftCTUAddr  = leftAvail  ? ctuRsAddr - 1 : -1;
+    int aboveCTUAddr = aboveAvail ? ctuRsAddr - frame_width_in_ctus : -1;
+    CtuAlfData& currAlfData = m_slice->getPic()->getCtuAlfData(ctuRsAddr);
+    // init currAlfData
+    memset(&currAlfData, 0, sizeof(currAlfData));
+    CtuAlfData  leftAlfData, aboveAlfData;
+    if (leftAvail)
+        leftAlfData = m_slice->getPic()->getCtuAlfData(leftCTUAddr);
+    if (aboveAvail)
+        aboveAlfData = m_slice->getPic()->getCtuAlfData(aboveCTUAddr);
+    if( m_slice->getTileGroupAlfEnabledFlag( COMPONENT_Y ) )
+    {
+        for( int compIdx = 0; compIdx < MAX_NUM_COMPONENT; compIdx++ )
+        {
+          if( m_slice->getTileGroupAlfEnabledFlag( ( ComponentID ) compIdx ) )
+          {
+            //uint8_t* ctbAlfFlag = m_slice->getPic()->getAlfCtuEnableFlag( compIdx );
+            int ctx = 0;
+              ctx += leftAlfData.alfCtuEnableFlag[compIdx];
+              ctx += aboveAlfData.alfCtuEnableFlag[compIdx];
+      
+            currAlfData.alfCtuEnableFlag[compIdx] = m_BinDecoder.decodeBin( Ctx::ctbAlfFlag( compIdx * 3 + ctx ) );
+      
+            if( isLuma( ( ComponentID ) compIdx ) && currAlfData.alfCtuEnableFlag[compIdx] )
+            {
+              currAlfData.alfCtbFilterIndex = readAlfCtuFilterIndex2( cs, ctuRsAddr );
+            }
 
-
+            if( isChroma( ( ComponentID ) compIdx ) )
+            {
+              const int apsIdx                  = m_slice->getTileGroupApsIdChroma();
+              CHECK( m_slice->getAlfAPSs()[apsIdx] == nullptr, "APS not initialized" );
+              const AlfSliceParam& alfParam     = m_slice->getAlfAPSs()[apsIdx]->getAlfAPSParam();
+              const int numAlts                 = alfParam.numAlternativesChroma;
+              currAlfData.alfCtuAlternative[compIdx - 1] = 0;
+              if( currAlfData.alfCtuEnableFlag[compIdx] )
+              {
+                uint8_t decoded = 0;
+                while( decoded < numAlts - 1 && m_BinDecoder.decodeBin( Ctx::ctbAlfAlternative( compIdx - 1 ) ) )
+                  ++decoded;
+                currAlfData.alfCtuAlternative[compIdx - 1] = decoded;
+              }
+            }
+          }
+        }
+    }
+    for( int compIdx = 1; compIdx < getNumberValidComponents( cs.pcv->chrFormat ); compIdx++ )
+    {
+      if( m_slice->getTileGroupCcAlfEnabledFlag( compIdx - 1 ) )
+      {
+          int            ctxt           = 0;
+          ctxt += ( leftAlfData.ccAlfFilterControl[compIdx - 1] ) ? 1 : 0;
+          ctxt += ( aboveAlfData.ccAlfFilterControl[compIdx - 1] ) ? 1 : 0;
+          ctxt += ( compIdx == COMPONENT_Cr ) ? 3 : 0;
+          int idcVal  = m_BinDecoder.decodeBin( Ctx::CcAlfFilterControlFlag( ctxt ) );
+          if ( idcVal )
+          {
+              const int apsIdx        = compIdx == 1 ? m_slice->getTileGroupCcAlfCbApsId() : m_slice->getTileGroupCcAlfCrApsId();
+              const int filterCount   = m_slice->getAlfAPSs()[apsIdx]->getCcAlfAPSParam().ccAlfFilterCount[compIdx - 1];
+              while ( ( idcVal != filterCount ) && m_BinDecoder.decodeBinEP() )
+              {
+                  idcVal++;
+              }
+          }
+          currAlfData.ccAlfFilterControl[compIdx - 1] = idcVal;
+      }
+    }
+}
 
 //================================================================================
 //  clause 7.3.11.4

--- a/source/Lib/DecoderLib/CABACReader.cpp
+++ b/source/Lib/DecoderLib/CABACReader.cpp
@@ -409,7 +409,9 @@ void CABACReader::readAlf(CodingStructure &cs, unsigned int ctuRsAddr, const Par
     int aboveCTUAddr = aboveAvail ? ctuRsAddr - frame_width_in_ctus : -1;
     CtuAlfData& currAlfData = m_slice->getPic()->getCtuAlfData(ctuRsAddr);
     // init currAlfData
+    GCC_WARNING_DISABLE_class_memaccess
     memset(&currAlfData, 0, sizeof(currAlfData));
+    GCC_WARNING_RESET
     CtuAlfData  leftAlfData, aboveAlfData;
     if (leftAvail)
         leftAlfData = m_slice->getPic()->getCtuAlfData(leftCTUAddr);

--- a/source/Lib/DecoderLib/CABACReader.h
+++ b/source/Lib/DecoderLib/CABACReader.h
@@ -91,7 +91,7 @@ public:
   void        sao                       ( CodingStructure&              cs,     unsigned        ctuRsAddr );
   void        readAlf                   ( CodingStructure&              cs,     unsigned        ctuRsAddr, const Partitioner& partitioner);
 
-  short       readAlfCtuFilterIndex2    ( CodingStructure&              cs,     unsigned        ctuRsAddr );
+  short       readAlfCtuFilterIndex     ( CodingStructure&              cs,     unsigned        ctuRsAddr );
 
   // coding (quad)tree (clause 7.3.11.4)
   bool        coding_tree               ( CodingStructure&              cs,     Partitioner&    pm,       CUCtx& cuCtx );

--- a/source/Lib/DecoderLib/CABACReader.h
+++ b/source/Lib/DecoderLib/CABACReader.h
@@ -89,10 +89,9 @@ public:
 
   // sao (clause 7.3.11.3)
   void        sao                       ( CodingStructure&              cs,     unsigned        ctuRsAddr );
+  void        readAlf                   ( CodingStructure&              cs,     unsigned        ctuRsAddr, const Partitioner& partitioner);
 
-  void        readAlfCtuFilterIndex     ( CodingStructure&              cs,     unsigned        ctuRsAddr );
-
-  void        ccAlfFilterControlIdc     ( CodingStructure&              cs, const ComponentID compID, const int curIdx, uint8_t *filterControlIdc, Position lumaPos, int filterCount );
+  short       readAlfCtuFilterIndex2    ( CodingStructure&              cs,     unsigned        ctuRsAddr );
 
   // coding (quad)tree (clause 7.3.11.4)
   bool        coding_tree               ( CodingStructure&              cs,     Partitioner&    pm,       CUCtx& cuCtx );

--- a/source/Lib/DecoderLib/DecSlice.cpp
+++ b/source/Lib/DecoderLib/DecSlice.cpp
@@ -91,10 +91,7 @@ void DecSlice::parseSlice( Slice* slice, InputBitstream* bitstream, int threadId
 
   if( startCtuTsAddr == 0 )
   {
-    cs.picture->resizeccAlfFilterControl( cs.pcv->sizeInCtus );
-    cs.picture->resizeAlfCtuEnableFlag  ( cs.pcv->sizeInCtus );
-    cs.picture->resizeAlfCtbFilterIndex ( cs.pcv->sizeInCtus );
-    cs.picture->resizeAlfCtuAlternative ( cs.pcv->sizeInCtus );
+    cs.picture->resizeCtuAlfData(cs.pcv->sizeInCtus);
   }
 
   AdaptiveLoopFilter::reconstructCoeffAPSs( *slice );

--- a/source/Lib/DecoderLib/DecSlice.cpp
+++ b/source/Lib/DecoderLib/DecSlice.cpp
@@ -89,11 +89,6 @@ void DecSlice::parseSlice( Slice* slice, InputBitstream* bitstream, int threadId
   const bool      wavefrontsEnabled           = cs.sps->getEntropyCodingSyncEnabledFlag();
   const bool      entryPointPresent           = cs.sps->getEntryPointsPresentFlag();
 
-  if( startCtuTsAddr == 0 )
-  {
-    cs.picture->resizeCtuAlfData(cs.pcv->sizeInCtus);
-  }
-
   AdaptiveLoopFilter::reconstructCoeffAPSs( *slice );
 
   CABACReader cabacReader;


### PR DESCRIPTION
Modify point：
1.Optimize the calculation of the filter parameters of the deblock
2.The parameters of ALF are changed from struct of array to array of struct to improve data access
3.CC-ALF of the two chroma components is performed simultaneously (if possible), so that the calculation results of luma can be reused

Test:
1.The conformance test is performed using the command line “make test-all”, and all tests pass;
2.Tested the decoding time of single thread and multi thread. For the 0/2/10/20 thread configuration, the average decoding time is 97.86%/97.37%/98.85%/99.23% as before;