### PR TITLE
Update CMake link to HTTPS & the redirect target

### DIFF
--- a/AUTHORS.md
+++ b/AUTHORS.md
@@ -8,3 +8,4 @@
 * Valeri George, , Fraunhofer HHI
 * Jens Güther, , Fraunhofer HHI
 * X Rayleigh, @xrayleigh2000, 
+* Kai Hollberg, @Schweinepriester,

--- a/README.md
+++ b/README.md
@@ -90,7 +90,7 @@ See the [Wiki-Page](https://github.com/fraunhoferhhi/vvdec/wiki) for more inform
 
 ## Build
 
-VVdeC uses CMake to describe and manage the build process. A working [CMake](http://www.cmake.org/) installation is required to build the software. In the following, the basic build steps are described. Please refer to the [Wiki](https://github.com/fraunhoferhhi/vvdec/wiki/Build) for the description of all build options.
+VVdeC uses CMake to describe and manage the build process. A working [CMake](https://cmake.org/) installation is required to build the software. In the following, the basic build steps are described. Please refer to the [Wiki](https://github.com/fraunhoferhhi/vvdec/wiki/Build) for the description of all build options.
 
 ### How to build using CMake?
 


### PR DESCRIPTION
Same as https://github.com/fraunhoferhhi/vvenc/pull/177:

Pretty much the title: http://www.cmake.org/ is being redirected to https://cmake.org/, so use HTTPS right away and skip the redirect.