### PR TITLE
adding musl libc compilation compatibility 

### DIFF
--- a/AUTHORS.md
+++ b/AUTHORS.md
@@ -8,3 +8,4 @@
 * Valeri George, , Fraunhofer HHI
 * Jens Güther, , Fraunhofer HHI
 * X Rayleigh, @xrayleigh2000, 
+* Matthieu Sauer, , 

--- a/source/Lib/vvdec/vvdecimpl.cpp
+++ b/source/Lib/vvdec/vvdecimpl.cpp
@@ -225,7 +225,7 @@ int VVDecImpl::reset()
   }
   m_cFrameStorageMap.clear();
 
-#if defined( __linux__ ) && !defined( ANDROID ) && defined( __GLIBC__ )
+#if defined( __linux__ ) && defined( __GLIBC__ )
   malloc_trim(0);
 #endif
 

--- a/source/Lib/vvdec/vvdecimpl.cpp
+++ b/source/Lib/vvdec/vvdecimpl.cpp
@@ -225,7 +225,7 @@ int VVDecImpl::reset()
   }
   m_cFrameStorageMap.clear();
 
-#if defined( __linux__ ) && !defined( ANDROID )
+#if defined( __linux__ ) && !defined( ANDROID ) && defined( __GLIBC__ )
   malloc_trim(0);
 #endif
 


### PR DESCRIPTION
I tried to use vvdec on an alpine linux (which use musl libc as default libc) and encountered a compilation error

The cause was the usage of malloc_trim as it is a GNU libc extension.

I therefore added a check with the macro __GLIBC__ which should always be defined when compiled using glibc
since musl libc is (or aims to be) fully POSIX compliant, I assume there is no other incompatibility here.