### PR TITLE
cmake: set version for shared object

### DIFF
--- a/source/Lib/vvdec/CMakeLists.txt
+++ b/source/Lib/vvdec/CMakeLists.txt
@@ -143,6 +143,10 @@ target_include_directories( ${LIB_NAME} SYSTEM INTERFACE $<BUILD_INTERFACE:${CMA
 
 target_link_libraries( ${LIB_NAME} ${INTEL_ITT_LINK_TARGET} Threads::Threads )
 
+set_target_properties( ${LIB_NAME} PROPERTIES
+                                   SOVERSION ${PROJECT_VERSION_MAJOR}
+                                   VERSION   ${PROJECT_VERSION} )
+
 # set the folder where to place the projects
 set_target_properties( ${LIB_NAME} PROPERTIES FOLDER lib )
 


### PR DESCRIPTION
produces the following files:
  libvvdec.so -> libvvdec.so.2
  libvvdec.so.2 -> libvvdec.so.2.0.0
  libvvdec.so.2.0.0

closes #136 