### PR TITLE
docs: stride is in bytes, not in samples

### DIFF
--- a/include/vvdec/vvdec.h
+++ b/include/vvdec/vvdec.h
@@ -407,7 +407,7 @@ typedef struct vvdecPlane
   unsigned char *ptr;                  // pointer to plane buffer
   uint32_t       width;                // width of the plane
   uint32_t       height;               // height of the plane
-  uint32_t       stride;               // stride (width + left margin + right margins) of plane in samples
+  uint32_t       stride;               // stride (width + left margin + right margins) of plane in bytes
   uint32_t       bytesPerSample;       // number of bytes per sample
   void          *allocator;            // opaque pointer to memory allocator (only valid, when memory is maintained by application)
 } vvdecPlane;


### PR DESCRIPTION
The comment for the stride in vvdecPlane states that it's in number of samples, but in reality it's in number of bytes, as seen in

https://github.com/fraunhoferhhi/vvdec/blob/3c43ba15b92abde704bb1b43d9bf38560ebf78b0/source/Lib/vvdec/vvdecimpl.cpp#L1203-L1205