### PR TITLE
CI: Use Windows Server 2022 for MSVC 64-bit and MinGW builds

### DIFF
--- a/.github/workflows/Build.yml
+++ b/.github/workflows/Build.yml
@@ -12,13 +12,14 @@ jobs:
     name: ${{ matrix.config.name }}
     runs-on: ${{ matrix.config.os }}
     strategy:
+      fail-fast: false
       matrix:
         config:
           - {
               name: "Windows MSVC 64 Bit",
-              os: windows-2019,
-              environment_script: "C:/Program Files (x86)/Microsoft Visual Studio/2019/Enterprise/VC/Auxiliary/Build/vcvars64.bat",
-              generators: "Visual Studio 16 2019",
+              os: windows-2022,
+              environment_script: "C:/Program Files/Microsoft Visual Studio/2022/Enterprise/VC/Auxiliary/Build/vcvars64.bat",
+              generators: "Visual Studio 17 2022",
               msvc_arch: x64
             }
           - {
@@ -30,7 +31,7 @@ jobs:
             }
           - {
               name: "Windows MinGW",
-              os: windows-2019,
+              os: windows-2022,
               cc: "gcc",
               cxx: "g++",
               generators: "MinGW Makefiles"
@@ -56,7 +57,7 @@ jobs:
     env:
       CMAKE_GENERATOR: "${{ matrix.config.generators }}"
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
     - run: git fetch --prune --unshallow
 
     - name: Ubuntu/Mac/MinGW build


### PR DESCRIPTION
A bit of maintenance on the build CI:
- Update MSVC 64-bit and MinGW builds from [Windows Server 2019](https://github.com/actions/runner-images/blob/main/images/win/Windows2019-Readme.md#visual-studio-enterprise-2019) to [Windows Server 2022](https://github.com/actions/runner-images/blob/main/images/win/Windows2022-Readme.md#visual-studio-enterprise-2022). This:
  - Updates Visual Studio from version 16.11 to version 17.7.
  - Updates Mingw-w64 from 8.1.0 to 12.2.0.
  - Uses the same CMake version, 3.27.6
- Update [actions/checkout](https://github.com/actions/checkout) to v4
- Continue CI if one build fails ([`fail-fast: false`](https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#jobsjob_idstrategyfail-fast))