### PR TITLE
Clean up the library interface for v3.0.0 (API & ABI change!)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -7,11 +7,11 @@ cmake_minimum_required( VERSION 3.12.0 FATAL_ERROR )
 cmake_policy( VERSION ${CMAKE_MAJOR_VERSION}.${CMAKE_MINOR_VERSION} )
 
 # project name
-project( vvdec VERSION 2.3.0 )
+project( vvdec VERSION 3.0.0 )
 # set alternative version numbering for release candidates
-#set( PROJECT_VERSION_RC rc1 )
+set( PROJECT_VERSION_RC rc1 )
 if( PROJECT_VERSION_RC )
-    set( PROJECT_VERSION "${PROJECT_VERSION}-rc${PROJECT_VERSION_RC}" )
+    set( PROJECT_VERSION "${PROJECT_VERSION}-${PROJECT_VERSION_RC}" )
 endif()
 
 list( APPEND CMAKE_MODULE_PATH "${CMAKE_CURRENT_SOURCE_DIR}/cmake/modules" )

--- a/cmake/modules/vvdecInstall.cmake
+++ b/cmake/modules/vvdecInstall.cmake
@@ -65,7 +65,7 @@ else()
     set( INSTALL_TARGETS "vvdec" )
 
     if ( NOT VVDEC_INSTALL_VVDECAPP )
-      install( CODE "message( WARNING \"\nThe vvdecapp binary is not installed by default anymore. To also install vvdecapp set '-DVVDEC_INSTALL_VVDECAPP=ON' (with make: 'install-vvdecapp=1')\" )" )
+      install( CODE "message( NOTICE \"The vvdecapp binary is not installed by default anymore. To also install vvdecapp set '-DVVDEC_INSTALL_VVDECAPP=ON' (with make: 'install-vvdecapp=1')\" )" )
     endif()
 endif()
 
@@ -124,7 +124,18 @@ endfunction()
 # create pkg-config file
 set( VVDEC_PKG_EXTRA_LIBS ${CMAKE_CXX_IMPLICIT_LINK_LIBRARIES} )
 if( VVDEC_PKG_EXTRA_LIBS )
-  list( TRANSFORM   VVDEC_PKG_EXTRA_LIBS REPLACE "^([^-].*)" "-l\\1" )  # only add a -l, when not already there
+  foreach( LIB ${VVDEC_PKG_EXTRA_LIBS} )
+    if((IS_ABSOLUTE ${LIB} AND EXISTS ${LIB}) OR (${LIB} MATCHES "^-"))
+      list( APPEND EXTRALIBS ${LIB} )
+    else()
+      list( APPEND EXTRALIBS "-l${LIB}" )
+    endif()
+  endforeach()
+
+  if( EXTRALIBS )
+    set(VVDEC_PKG_EXTRA_LIBS ${EXTRALIBS})
+  endif()
+
   list( REMOVE_ITEM VVDEC_PKG_EXTRA_LIBS "-lc" )
 endif()
 

--- a/include/vvdec/vvdec.h
+++ b/include/vvdec/vvdec.h
@@ -97,7 +97,7 @@ typedef enum
   VVDEC_ERR_CPU               = -30,   // unsupported CPU SSE 4.1 needed
   VVDEC_TRY_AGAIN             = -40,   // decoder needs more input and cannot return a picture
   VVDEC_EOF                   = -50    // end of file
-}vvdecErrorCodes;
+} vvdecErrorCodes;
 
 /*
   \enum LogLevel
@@ -112,7 +112,7 @@ typedef enum
   VVDEC_NOTICE  = 4,
   VVDEC_VERBOSE = 5,
   VVDEC_DETAILS = 6
-}vvdecLogLevel;
+} vvdecLogLevel;
 
 /*
   \enum SIMD_Extension
@@ -138,18 +138,7 @@ typedef enum
   VVDEC_SIMD_SIMDE_ANY= 3,
   VVDEC_SIMD_MAX      = VVDEC_SIMD_SIMDE_ANY
 #endif
-}vvdecSIMD_Extension;
-
-/*
-  \enum vvdecObsoleteEnum
-  Placeholder for an obsolete field, that will be removed later. Don't use.
-*/
-typedef enum
-{
-  VVDEC_OBSOLETE_ENUM_0 = 0,
-  VVDEC_OBSOLETE_ENUM_1 = 1,
-  VVDEC_OBSOLETE_ENUM_2 = 2
-} vvdecObsoleteEnum;
+} vvdecSIMD_Extension;
 
 /*
   \enum vvdecErrHandlingFlags
@@ -172,7 +161,7 @@ typedef enum
   VVDEC_CF_YUV420_PLANAR =  1,         // YUV420 planar color format
   VVDEC_CF_YUV422_PLANAR =  2,         // YUV422 planar color format
   VVDEC_CF_YUV444_PLANAR =  3          // YUV444 planar color format
-}vvdecColorFormat;
+} vvdecColorFormat;
 
 /*
   The class InterlaceFormat enumerates several supported picture formats.
@@ -194,7 +183,7 @@ typedef enum
   VVDEC_FF_BOT_PW_PREV = 10,           // bottom field (is paired with previous top field)
   VVDEC_FF_TOP_PW_NEXT = 11,           // top field    (is paired with next bottom field)
   VVDEC_FF_BOT_PW_NEXT = 12,           // bottom field (is paired with next top field)
-}vvdecFrameFormat;
+} vvdecFrameFormat;
 
 /*
   The class SliceType enumerates several supported slice types.
@@ -205,7 +194,7 @@ typedef enum
   VVDEC_SLICETYPE_P,
   VVDEC_SLICETYPE_B,
   VVDEC_SLICETYPE_UNKNOWN
-}vvdecSliceType;
+} vvdecSliceType;
 
 typedef enum
 {
@@ -248,7 +237,7 @@ typedef enum
   VVC_NAL_UNIT_UNSPECIFIED_30,
   VVC_NAL_UNIT_UNSPECIFIED_31,
   VVC_NAL_UNIT_INVALID
-}vvdecNalType;
+} vvdecNalType;
 
 
 typedef enum
@@ -257,7 +246,7 @@ typedef enum
   VVDEC_CT_U = 1,                      // U component
   VVDEC_CT_V = 2,                      // V component
   VVDEC_MAX_NUM_COMPONENT = 3
-}vvdecComponentType;
+} vvdecComponentType;
 
 
 /* vvdecAccessUnit
@@ -337,7 +326,7 @@ typedef struct vvdecVui
   bool       overscanAppropriateFlag;
   bool       videoSignalTypePresentFlag;
   bool       videoFullRangeFlag;
-}vvdecVui;
+} vvdecVui;
 
 /*
   The struct vvdecHrd contains information about the Hypothetical Reference Decoder
@@ -355,14 +344,14 @@ typedef struct vvdecHrd
   uint32_t   cpbSizeScale;
   uint32_t   cpbSizeDuScale;
   uint32_t   hrdCpbCnt;
-}vvdecHrd;
+} vvdecHrd;
 
 typedef enum
 {
   VVDEC_GENEREAL_NAL_HRD_PARAM = 0,
   VVDEC_GENEREAL_VCL_HRD_PARAM = 1,
   VVDEC_NUM_GENEREAL_HRD_PARAM = 2
-}vvdecGeneralHrdParamsType;
+} vvdecGeneralHrdParamsType;
 
 /*
   The struct vvdecOlsHrd contains information about the Output Layer Set HRD
@@ -379,15 +368,20 @@ typedef struct vvdecOlsHrd
   uint32_t ducpbSizeValueMinus1[32][VVDEC_NUM_GENEREAL_HRD_PARAM];
   uint32_t duBitRateValueMinus1[32][VVDEC_NUM_GENEREAL_HRD_PARAM];
   bool     cbrFlag             [32][VVDEC_NUM_GENEREAL_HRD_PARAM];
-}vvdecOlsHrd;
+} vvdecOlsHrd;
 
 /*
   The struct vvdecSeqInfo contains some selected fields extracted from the Sequence Parameter Set (SPS)
  */
 typedef struct vvdecSeqInfo
 {
-  uint32_t maxWidth;    // the maxium picture width contained in the current sequence (sps_pic_width_max_in_luma_samples)
-  uint32_t maxHeight;   // the maxium picture height contained in the current sequence (sps_pic_height_max_in_luma_samples)
+  uint32_t maxWidth;                   // the maxium picture width contained in the current sequence (sps_pic_width_max_in_luma_samples)
+  uint32_t maxHeight;                  // the maxium picture height contained in the current sequence (sps_pic_height_max_in_luma_samples)
+
+  void*    reservedPtr_1;              // reserved space for future use
+  void*    reservedPtr_2;              // ...
+  int64_t  reserved_1;                 // ...
+  int64_t  reserved_2;                 // ...
 } vvdecSeqInfo;
 
 /*
@@ -405,6 +399,11 @@ typedef struct vvdecPicAttributes
   vvdecHrd       *hrd;                 // if available, pointer to HRD (Hypothetical Reference Decoder)
   vvdecOlsHrd    *olsHrd;              // if available, pointer to OLS HRD (Output Layer Set Hypothetical Reference Decoder)
   vvdecSeqInfo   *seqInfo;             // if available, pointer to some data extracted from the SPS (Sequence Parameter Set)
+
+  void*           reservedPtr_1;       // reserved space for future use
+  void*           reservedPtr_2;       // ...
+  int64_t         reserved_1;          // ...
+  int64_t         reserved_2;          // ...
 } vvdecPicAttributes;
 
 /*
@@ -438,7 +437,7 @@ typedef struct vvdecFrame
   uint64_t            cts;             // composition time stamp in TicksPerSecond
   bool                ctsValid;        // composition time stamp valid flag (true: valid, false: CTS not set)
   vvdecPicAttributes *picAttributes;   // pointer to vvdecPicAttributes that might be NULL, containing decoder side information
-}vvdecFrame;
+} vvdecFrame;
 
 /*
   The struct vvdecParams is a container for decoder configuration parameters.
@@ -448,20 +447,17 @@ typedef struct vvdecParams
 {
   int                   threads;            // thread count                          ( default: -1 )
   int                   parseDelay;         // number of frames to parse in parallel ( default: -1 )
-  vvdecObsoleteEnum     obsolete_1;         // removed feature, must be 0
   vvdecLogLevel         logLevel;           // verbosity level
   bool                  verifyPictureHash;  // verify picture, if digest is available, true: check hash in SEI messages if available, false: ignore SEI message
-  bool                  obsolete_2;         // removed feature, muste be 0
+  bool                  filmGrainSynthesis; // set film grain synthesis using Film Grain Charactersitics SEI ( default: true )
   vvdecSIMD_Extension   simd;               // set specific simd optimization (default: max. availalbe)
   void                 *opaque;             // opaque pointer for private user data ( can be used to carry application specific data or contexts )
   vvdecErrHandlingFlags errHandlingFlags;   // set of flags defining how to handle bitstream errors
-  int                   parseThreads;       // DEPRECATED. Use `parseDelay` instead. This will be removed in the future. Until then, this value is copied to parseDelay if set.
-  bool                  filmGrainSynthesis; // set film grain synthesis using Film Grain Charactersitics SEI ( default: true )
-  int8_t                padding2_1;         // reserved space for future parameters
-  int8_t                padding2_2;
-  int8_t                padding2_3;
-  int                   padding3;
-  int                   padding4;
+
+  int32_t               reserved_1;         // reserved space for future parameters
+  int32_t               reserved_2;         // ...
+  int32_t               reserved_3;         // ...
+  int32_t               reserved_4;         // ...
 } vvdecParams;
 
 /* vvdecCreateBufferCallback

--- a/source/Lib/vvdec/vvdec.cpp
+++ b/source/Lib/vvdec/vvdec.cpp
@@ -72,7 +72,6 @@ VVDEC_DECL void vvdec_params_default(vvdecParams *params)
   params->simd               = VVDEC_SIMD_DEFAULT;      // set specific simd optimization (default: max. availalbe)
   params->errHandlingFlags   = VVDEC_ERR_HANDLING_OFF;  // no special error handling
   params->filmGrainSynthesis = true;                    // enable film grain synthesis using Film Grain Charactersitics SEI ( default: true )
-  params->parseThreads       = -1;                      // DEPRECATED. Use `parseDelay` instead. Will be removed in the future. Until then, this value is copied to parseDelay if set.
 }
 
 VVDEC_DECL vvdecParams* vvdec_params_alloc()
@@ -179,25 +178,6 @@ static int paramCheck( vvdecParams *params )
     ret = -1;
   }
 
-  if( params->parseThreads != -1 )
-  {
-    vvdec::msg( vvdec::WARNING, "Used deprecated field parseThreads. Use parseDelay instead. parseThreads will be removed in the future. Until then, this value is copied to parseDelay if set.\n" );
-
-    if( params->parseThreads != params->parseDelay && params->parseDelay != -1 )
-    {
-      vvdec::msg( vvdec::ERROR, "parseDelay and parseThreads were both set, but to different values. Only set parseDelay in the future.\n" );
-      ret = -1;
-    }
-  }
-
-  if( params->obsolete_1 != 0 || params->obsolete_2 != 0 )
-  {
-    vvdec::msg( vvdec::ERROR,
-                "The fields upscaleOutput and removePadding in vvdecParams and the corresponding features were removed from vvdec.\n"
-                "The new fields in the same positions vvdecParams::obsolete_1 and vvdecParams::obsolete_2 must be 0.\n" );
-    ret = -1;
-  }
-
   return ret;
 }
 
@@ -212,11 +192,6 @@ VVDEC_DECL vvdecDecoder* vvdec_decoder_open( vvdecParams *params)
   if ( 0 != paramCheck( params ))
   {
     return nullptr;
-  }
-
-  if( params->parseThreads != -1 && params->parseDelay == -1 )   // overwrite parseDelay with deprecated value parseThreads if set
-  {
-    params->parseDelay = params->parseThreads;
   }
 
   vvdec::VVDecImpl* decCtx = new vvdec::VVDecImpl();

--- a/source/Lib/vvdec/wasm_bindings.cpp
+++ b/source/Lib/vvdec/wasm_bindings.cpp
@@ -161,10 +161,11 @@ EMSCRIPTEN_BINDINGS( vvdec )
 
   class_<vvdecParams>( "Params" )
     .constructor( vvdec_params_alloc )
-    .property( "threads",           &vvdecParams::threads           )
-    .property( "parseThreads",      &vvdecParams::parseThreads      )
-    .property( "logLevel",          &vvdecParams::logLevel          )
-    .property( "verifyPictureHash", &vvdecParams::verifyPictureHash )
+    .property( "threads",            &vvdecParams::threads            )
+    .property( "parseDelay",         &vvdecParams::parseDelay         )
+    .property( "logLevel",           &vvdecParams::logLevel           )
+    .property( "verifyPictureHash",  &vvdecParams::verifyPictureHash  )
+    .property( "filmGrainSynthesis", &vvdecParams::filmGrainSynthesis )
     // .property( "simd",              &vvdecParams::simd              ) // SIMD is currently hardcoded to SSE42 for wasm
   ;
 


### PR DESCRIPTION
This version marks an interface change, so you might need to update your code if it fails to compile:
- `vvdecParams::parseThreads` was finally removed and is now called `vvdecParams::parseDelay`
- the feature `vvdecParams::upscaleOutput` has been removed