### PR TITLE
Remove `-lgcc_s` from the list of library dependencies in .pc file

### DIFF
--- a/cmake/modules/vvdecInstall.cmake
+++ b/cmake/modules/vvdecInstall.cmake
@@ -144,6 +144,7 @@ if( VVDEC_PKG_EXTRA_LIBS )
   endif()
 
   list( REMOVE_ITEM VVDEC_PKG_EXTRA_LIBS "-lc" )
+  list( REMOVE_ITEM VVDEC_PKG_EXTRA_LIBS "-lgcc_s" )
 endif()
 
 resolve_target_interface_libs( vvdec VVDEC_PKG_INTERFACE_LIBS )


### PR DESCRIPTION
When `-lgcc_s` is in the list of required libraries in .pc, it's impossible to avoid dependency to dynamic `libgcc_s.so` when linking gcc statically inside target binary using `-static-libgcc` option.