### PR TITLE
cmake: Install vvdecapp if VVDEC_INSTALL_VVDECAPP set

### DIFF
--- a/cmake/modules/vvdecInstall.cmake
+++ b/cmake/modules/vvdecInstall.cmake
@@ -87,7 +87,7 @@ if( VVDEC_INSTALL_VVDECAPP )
 endif()
 
 # install emscripten generated files
-if( ${CMAKE_SYSTEM_NAME} STREQUAL "Emscripten" )
+if( ${CMAKE_SYSTEM_NAME} STREQUAL "Emscripten" AND VVDEC_INSTALL_VVDECAPP)
   install( PROGRAMS $<TARGET_FILE_DIR:vvdecapp>/vvdecapp.wasm DESTINATION ${RUNTIME_DEST} )
   install( PROGRAMS $<TARGET_FILE_DIR:vvdecapp>/vvdecapp.worker.js DESTINATION ${RUNTIME_DEST} )
 endif()


### PR DESCRIPTION
Without this change and the following compilation arguments (`-DVVDEC_LIBRARY_ONLY=ON -DVVDEC_INSTALL_VVDECAPP=OFF`) this error is shown:


```
CMake Error at cmake_install.cmake:115 (file):
  file INSTALL cannot find
  "/home/forccon/checkout/fluendo/tmp/spirit-stream/build/gst.wasm_web_wasm32/sources/web_wasm32/fraunhofer_vvcdec-3.0.0/bin/release-static/vvdecapp.wasm":
  No such file or directory.
```