### PR TITLE
Add userData to input frames/ouput access units (protected by a macro) #221

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -160,7 +160,7 @@ set( VVDEC_ENABLE_LINK_TIME_OPT             ON  CACHE BOOL   "Enable link time o
 
 set( VVDEC_ENABLE_WERROR                    ON  CACHE BOOL   "Treat warnings as errors (-Werror or /WX)" )
 
-set( VVDEC_ENABLE_UNSTABLE_API              OFF CACHE BOOL   "Enable unstable API" )
+set( VVDEC_ENABLE_UNSTABLE_API              OFF CACHE BOOL   "Enable unstable API (include 3.0.0 API and ABI incompatible interface extensions)" )
 
 if( CMAKE_CXX_COMPILER_ID STREQUAL "GNU" OR
     CMAKE_CXX_COMPILER_ID STREQUAL "Clang" )

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -160,6 +160,8 @@ set( VVDEC_ENABLE_LINK_TIME_OPT             ON  CACHE BOOL   "Enable link time o
 
 set( VVDEC_ENABLE_WERROR                    ON  CACHE BOOL   "Treat warnings as errors (-Werror or /WX)" )
 
+set( VVDEC_ENABLE_UNSTABLE_API              OFF CACHE BOOL   "Enable unstable API" )
+
 if( CMAKE_CXX_COMPILER_ID STREQUAL "GNU" OR
     CMAKE_CXX_COMPILER_ID STREQUAL "Clang" )
 
@@ -286,6 +288,13 @@ if( VVDEC_ENABLE_WERROR )
     add_compile_options( "$<$<OR:$<CXX_COMPILER_ID:GNU>,$<CXX_COMPILER_ID:Clang>,$<CXX_COMPILER_ID:AppleClang>>:-Werror>" )
     add_compile_options( "$<$<CXX_COMPILER_ID:MSVC>:/WX>" )
 endif()
+
+set( VVDEC_USE_UNSTABLE_API 0 )
+if( VVDEC_ENABLE_UNSTABLE_API )
+  set( VVDEC_USE_UNSTABLE_API 1 )
+endif()
+
+configure_file( include/vvdec/vvdec.h.in ${CMAKE_BINARY_DIR}/vvdec/vvdec.h @ONLY )
 
 if( VVDEC_ENABLE_X86_SIMD )
   if( ( UNIX OR MINGW ) AND VVDEC_OPT_TARGET_ARCH )

--- a/Makefile
+++ b/Makefile
@@ -63,6 +63,10 @@ ifneq ($(enable-werror),)
 CONFIG_OPTIONS += -DVVDEC_ENABLE_WERROR=$(enable-werror)
 endif
 
+ifneq ($(enable-unstable-api),)
+CONFIG_OPTIONS += -DVVDEC_ENABLE_UNSTABLE_API=$(enable-unstable-api)
+endif
+
 ifneq ($(osx-arch),)
 CONFIG_OPTIONS += -DCMAKE_OSX_ARCHITECTURES=$(osx-arch)
 endif

--- a/cmake/modules/vvdecInstall.cmake
+++ b/cmake/modules/vvdecInstall.cmake
@@ -55,8 +55,8 @@ endmacro( install_exe_pdb )
 target_include_directories( vvdec  SYSTEM INTERFACE $<INSTALL_INTERFACE:${CMAKE_INSTALL_INCLUDEDIR}> )
 
 # install headers
-install( FILES     ${CMAKE_BINARY_DIR}/vvdec/version.h  DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}/vvdec )
-install( DIRECTORY include/vvdec                        DESTINATION ${CMAKE_INSTALL_INCLUDEDIR} )
+install( DIRECTORY ${CMAKE_BINARY_DIR}/vvdec  DESTINATION ${CMAKE_INSTALL_INCLUDEDIR} )
+install( DIRECTORY include/vvdec              DESTINATION ${CMAKE_INSTALL_INCLUDEDIR} PATTERN "*.in" EXCLUDE )
 
 if( VVDEC_INSTALL_VVDECAPP AND VVDEC_LIBRARY_ONLY )
   message( FATAL_ERROR "VVDEC_INSTALL_VVDECAPP conflicts with VVDEC_LIBRARY_ONLY" )

--- a/include/vvdec/vvdec.h.in
+++ b/include/vvdec/vvdec.h.in
@@ -52,6 +52,8 @@ POSSIBILITY OF SUCH DAMAGE.
 #define VVDEC_NAMESPACE_BEGIN
 #define VVDEC_NAMESPACE_END
 
+#define VVDEC_USE_UNSTABLE_API @VVDEC_USE_UNSTABLE_API@
+
 #ifdef __cplusplus
 extern "C" {
 #endif
@@ -287,6 +289,9 @@ typedef struct vvdecAccessUnit
   bool            ctsValid;            // composition time stamp valid flag (true: valid, false: CTS not set)
   bool            dtsValid;            // decoding time stamp valid flag (true: valid, false: DTS not set)
   bool            rap;                 // random access point flag (true: AU is random access point, false: sequential access)
+#if VVDEC_USE_UNSTABLE_API
+  void*           userData;            // user data to be returned in corresponding output YUV buffer
+#endif
 } vvdecAccessUnit;
 
 /* vvdec_accessUnit_alloc:
@@ -420,8 +425,7 @@ typedef struct vvdecPicAttributes
   vvdecOlsHrd*      olsHrd;            // if available, pointer to OLS HRD (Output Layer Set Hypothetical Reference Decoder)
   vvdecSeqInfo*     seqInfo;           // if available, pointer to some data extracted from the SPS (Sequence Parameter Set)
   vvdecPicHashError picHashError;      // result of the decoded picture hash verification if enabled
-
-  void*             reservedPtr_1;     // reserved space for future use
+  void*             userData;          // user data for private data that is attached on the input vvdecAccessUnit with same cts
   void*             reservedPtr_2;     // ...
   int64_t           reserved_1;        // ...
   int64_t           reserved_2;        // ...

--- a/include/vvdec/vvdec.h.in
+++ b/include/vvdec/vvdec.h.in
@@ -291,6 +291,9 @@ typedef struct vvdecAccessUnit
   bool            rap;                 // random access point flag (true: AU is random access point, false: sequential access)
 #if VVDEC_USE_UNSTABLE_API
   void*           userData;            // user data to be returned in corresponding output YUV buffer
+  void*           reservedPtr_1;       // ...
+  int64_t         reserved_1;          // ...
+  int64_t         reserved_2;          // ...
 #endif
 } vvdecAccessUnit;
 

--- a/source/Lib/CommonLib/NAL.h
+++ b/source/Lib/CommonLib/NAL.h
@@ -62,7 +62,7 @@ struct NALUnit
   uint64_t    m_cts      = 0;            ///< composition time stamp in TicksPerSecond
   uint64_t    m_dts      = 0;            ///< decoding time stamp in TicksPerSecond
   bool        m_rap      = false;        ///< random access point flag
-
+  void       *m_userData = nullptr;      ///< opaque user data
   NALUnit(const NALUnit &src)
     : m_nalUnitType (src.m_nalUnitType)
     , m_temporalId  (src.m_temporalId)

--- a/source/Lib/CommonLib/Picture.cpp
+++ b/source/Lib/CommonLib/Picture.cpp
@@ -153,6 +153,7 @@ void Picture::resetForUse( int _layerId )
   eNalUnitType        = NAL_UNIT_INVALID;
   bits                = 0;
   rap                 = 0;
+  userData            = nullptr;
   decodingOrderNumber = 0;
 
   sliceSubpicIdx.clear();

--- a/source/Lib/CommonLib/Picture.h
+++ b/source/Lib/CommonLib/Picture.h
@@ -221,6 +221,7 @@ public:
   NalUnitType eNalUnitType = NAL_UNIT_INVALID;
   uint32_t    bits         = 0;   // input nal bit count
   bool        rap          = 0;   // random access point flag
+  void       *userData     = nullptr;      ///< opaque user data
   int         decodingOrderNumber = 0;
 
   std::vector<int>        sliceSubpicIdx;

--- a/source/Lib/DecoderLib/DecLibParser.cpp
+++ b/source/Lib/DecoderLib/DecLibParser.cpp
@@ -727,6 +727,7 @@ bool DecLibParser::xDecodeSliceMain( InputNALUnit& nalu )
   m_pcParsePic->cts              = nalu.m_cts;
   m_pcParsePic->dts              = nalu.m_dts;
   m_pcParsePic->rap              = nalu.m_rap;
+  m_pcParsePic->userData         = nalu.m_userData;
   m_pcParsePic->bits            += nalu.m_bits + m_nonVCLbits;
   m_pcParsePic->layerId          = nalu.m_nuhLayerId;
   m_pcParsePic->subLayerNonReferencePictureDueToSTSA = false;

--- a/source/Lib/vvdec/vvdecimpl.cpp
+++ b/source/Lib/vvdec/vvdecimpl.cpp
@@ -393,6 +393,9 @@ int VVDecImpl::decode( vvdecAccessUnit& rcAccessUnit, vvdecFrame** ppcFrame )
           if( rcAccessUnit.dtsValid ){  nalu.m_dts = rcAccessUnit.dts; }
           nalu.m_rap = rcAccessUnit.rap;
           nalu.m_bits = ( numNaluBytes + iStartCodeSizeVec[iAU] ) * 8;
+#if VVDEC_USE_UNSTABLE_API
+          nalu.m_userData = rcAccessUnit.userData;
+#endif
 
           pcPic = m_cDecLib->decode( nalu );
 
@@ -1062,6 +1065,9 @@ int VVDecImpl::xAddPicture( Picture* pcPic )
                        : ( pcPic->picCheckedDPH ? VVDEC_DPH_OK                // and then pcPic->picCheckedDPH, because it will only be set when all subpics
                                                 : VVDEC_DPH_NOT_VERIFIED );   // have been checked, but the DPH-SEIs for some subpics could be missing,
 
+#if VVDEC_USE_UNSTABLE_API
+  cFrame.picAttributes->userData = pcPic->userData;
+#endif
   if( pcPic->fieldPic )
   {
     cFrame.frameFormat = pcPic->topField ? VVDEC_FF_TOP_FIELD : VVDEC_FF_BOT_FIELD;

--- a/source/Lib/vvdec/wasm_bindings.cpp
+++ b/source/Lib/vvdec/wasm_bindings.cpp
@@ -143,6 +143,9 @@ EMSCRIPTEN_BINDINGS( vvdec )
     .property( "ctsValid",        &vvdecAccessUnit::ctsValid        )
     .property( "dtsValid",        &vvdecAccessUnit::dtsValid        )
     .property( "rap",             &vvdecAccessUnit::rap             )
+#if VVDEC_USE_UNSTABLE_API
+    .property( "userData",        &vvdecAccessUnit::userData        )
+#endif
   ;
 
 


### PR DESCRIPTION
Macro `VVDEC_USE_UNSTABLE_API` in the external include shows how it was compiled. Will not be enabled per default until 4.0.0

Fixes #221