### PR TITLE
cmake: fix i686 cpu-type detection

### DIFF
--- a/cmake/modules/vvdecCompilerSupport.cmake
+++ b/cmake/modules/vvdecCompilerSupport.cmake
@@ -83,17 +83,17 @@ function( detect_target_architecture output_var )
   elseif( NOT CMAKE_SYSTEM_PROCESSOR STREQUAL CMAKE_HOST_SYSTEM_PROCESSOR )
     message( DEBUG  "sys != host ${CMAKE_SYSTEM_PROCESSOR} STREQUAL ${CMAKE_HOST_SYSTEM_PROCESSOR} " )
     # cross compiling: CMAKE_SYSTEM_PROCESSOR was set explicitly, so we use that as first guess
-    _append_cpu_type_guess( target_arch_list "${CMAKE_SYSTEM_PROCESSOR}" )
+    _append_cpu_type_guess( target_arch_list CMAKE_SYSTEM_PROCESSOR )
   endif()
 
   # build list of architectures in order of probability
-  _append_cpu_type_guess( target_arch_list "${CMAKE_VS_PLATFORM_NAME}" )
-  _append_cpu_type_guess( target_arch_list "${CMAKE_OSX_ARCHITECTURES}" )
-  _append_cpu_type_guess( target_arch_list "${CMAKE_CXX_COMPILER_ARCHITECTURE_ID}" ) # set by msvc, wen not using msbuild
-  _append_cpu_type_guess( target_arch_list "${CMAKE_ANDROID_ARCH_ABI}" )
-  _append_cpu_type_guess( target_arch_list "${CMAKE_C_LIBRARY_ARCHITECTURE}" )
-  _append_cpu_type_guess( target_arch_list "${CMAKE_SYSTEM_PROCESSOR}" )
-  _append_cpu_type_guess( target_arch_list "${CMAKE_HOST_SYSTEM_PROCESSOR}" )
+  _append_cpu_type_guess( target_arch_list CMAKE_VS_PLATFORM_NAME )
+  _append_cpu_type_guess( target_arch_list CMAKE_OSX_ARCHITECTURES )
+  _append_cpu_type_guess( target_arch_list CMAKE_CXX_COMPILER_ARCHITECTURE_ID ) # set by msvc, wen not using msbuild
+  _append_cpu_type_guess( target_arch_list CMAKE_ANDROID_ARCH_ABI )
+  _append_cpu_type_guess( target_arch_list CMAKE_C_LIBRARY_ARCHITECTURE )
+  _append_cpu_type_guess( target_arch_list CMAKE_SYSTEM_PROCESSOR )
+  _append_cpu_type_guess( target_arch_list CMAKE_HOST_SYSTEM_PROCESSOR )
   list( APPEND target_arch_list "UNKNOWN" ) # no architecture for which we have specific optimizations
   message( DEBUG "target_arch_list: ${target_arch_list}" )
 
@@ -104,11 +104,13 @@ function( detect_target_architecture output_var )
   set( ${output_var} "${detected_arch}" PARENT_SCOPE )
 endfunction()
 
-function( _append_cpu_type_guess output_list input_str )
+function( _append_cpu_type_guess output_list input_var )
+  message( DEBUG "cpu_type_guess: input ${input_var}=${${input_var}}" )
+  set( input_str ${${input_var}} )
   set( ret ${${output_list}} )
 
   string( TOLOWER "${input_str}" input_lower )
-  if( ${input_lower} MATCHES "x86\|i386\|x64\|win32\|amd64" )
+  if( ${input_lower} MATCHES "x86\|i.86\|x64\|win32\|amd64" )
     list( APPEND ret "X86" )
   elseif( ${input_lower} MATCHES "aarch64\|arm")
     list( APPEND ret "ARM" )


### PR DESCRIPTION
and improve cmake debug logging

see [vvenc#541](https://github.com/fraunhoferhhi/vvenc/issues/541)