### PR TITLE
Github Actions: use windows-2025 image

### DIFF
--- a/.github/workflows/Build.yml
+++ b/.github/workflows/Build.yml
@@ -30,6 +30,13 @@ jobs:
               msvc_arch: Win32
             }
           - {
+              name: "Windows MSVC ARM64",
+              os: windows-2025,
+              environment_script: "C:/Program Files/Microsoft Visual Studio/2022/Enterprise/VC/Auxiliary/Build/vcvars64.bat",
+              generators: "Visual Studio 17 2022",
+              msvc_arch: arm64
+            }
+          - {
               name: "Windows MinGW",
               os: windows-2025,
               cc: "gcc",


### PR DESCRIPTION
Use windows-2025 image instead of deprecated windows-2019. See: https://github.com/actions/runner-images/issues/12045