### PR TITLE
Rename filterXxY to filterWxH

### DIFF
--- a/source/Lib/CommonLib/InterPrediction.cpp
+++ b/source/Lib/CommonLib/InterPrediction.cpp
@@ -830,11 +830,11 @@ void InterPrediction::xPredInterBlk( const ComponentID&    compID,
   }
   else if( width == 16 )
   {
-    m_if.filter16x16( compID, refPtr, refStride, dstBuf, dstStride, 16, height, xFrac, yFrac, rndRes, chFmt, clpRng, useAltHpelIf );
+    m_if.filter16xH( compID, refPtr, refStride, dstBuf, dstStride, 16, height, xFrac, yFrac, rndRes, chFmt, clpRng, useAltHpelIf );
   }
   else if( width == 8 )
   {
-    m_if.filter8x8( compID, refPtr, refStride, dstBuf, dstStride, 8, height, xFrac, yFrac, rndRes, chFmt, clpRng, useAltHpelIf );
+    m_if.filter8xH( compID, refPtr, refStride, dstBuf, dstStride, 8, height, xFrac, yFrac, rndRes, chFmt, clpRng, useAltHpelIf );
   }
   else
   {

--- a/source/Lib/CommonLib/InterpolationFilter.cpp
+++ b/source/Lib/CommonLib/InterpolationFilter.cpp
@@ -378,20 +378,20 @@ InterpolationFilter::InterpolationFilter()
   m_filterCopy[1][0]   = filterCopy<true, false>;
   m_filterCopy[1][1]   = filterCopy<true, true>;
 
-  m_filter4x4[0][0] = filterXxY_N8<false, 4>;
-  m_filter4x4[0][1] = filterXxY_N8<true , 4>;
-  m_filter4x4[1][0] = filterXxY_N4<false, 4>;
-  m_filter4x4[1][1] = filterXxY_N4<true , 4>;
+  m_filter4x4[0][0]    = filterWxH_N8<false, 4>;
+  m_filter4x4[0][1]    = filterWxH_N8<true , 4>;
+  m_filter4x4[1][0]    = filterWxH_N4<false, 4>;
+  m_filter4x4[1][1]    = filterWxH_N4<true , 4>;
 
-  m_filter8x8[0][0] = filterXxY_N8<false, 8>;
-  m_filter8x8[0][1] = filterXxY_N8<true , 8>;
-  m_filter8x8[1][0] = filterXxY_N4<false, 8>;
-  m_filter8x8[1][1] = filterXxY_N4<true , 8>;
+  m_filter8xH[0][0]    = filterWxH_N8<false, 8>;
+  m_filter8xH[0][1]    = filterWxH_N8<true , 8>;
+  m_filter8xH[1][0]    = filterWxH_N4<false, 8>;
+  m_filter8xH[1][1]    = filterWxH_N4<true , 8>;
 
-  m_filter16x16[0][0] = filterXxY_N8<false, 16>;
-  m_filter16x16[0][1] = filterXxY_N8<true , 16>;
-  m_filter16x16[1][0] = filterXxY_N4<false, 16>;
-  m_filter16x16[1][1] = filterXxY_N4<true , 16>;
+  m_filter16xH[0][0]   = filterWxH_N8<false, 16>;
+  m_filter16xH[0][1]   = filterWxH_N8<true , 16>;
+  m_filter16xH[1][0]   = filterWxH_N4<false, 16>;
+  m_filter16xH[1][1]   = filterWxH_N4<true , 16>;
 
   m_filterN2_2D = scalarFilterN2_2D;
 
@@ -686,7 +686,7 @@ void InterpolationFilter::filter4x4( const ComponentID compID, const Pel* src, c
   }
 }
 
-void InterpolationFilter::filter8x8( const ComponentID compID, const Pel* src, const ptrdiff_t srcStride, Pel* dst, const ptrdiff_t dstStride, int width, int height, int fracX, int fracY, bool isLast, const ChromaFormat fmt, const ClpRng& clpRng, bool useAltHpelIf )
+void InterpolationFilter::filter8xH( const ComponentID compID, const Pel* src, const ptrdiff_t srcStride, Pel* dst, const ptrdiff_t dstStride, int width, int height, int fracX, int fracY, bool isLast, const ChromaFormat fmt, const ClpRng& clpRng, bool useAltHpelIf )
 {
   const int vFilterSize = isLuma( compID ) ? NTAPS_LUMA : NTAPS_CHROMA;
 
@@ -696,7 +696,7 @@ void InterpolationFilter::filter8x8( const ComponentID compID, const Pel* src, c
     const TFilterCoeff* vc = ( fracX == 8 && useAltHpelIf ) ? m_lumaAltHpelIFilter : m_lumaFilter[fracX];
     const TFilterCoeff* hc = ( fracY == 8 && useAltHpelIf ) ? m_lumaAltHpelIFilter : m_lumaFilter[fracY];
 
-    m_filter8x8[0][isLast]( clpRng, src, srcStride, dst, dstStride, 8, height, vc, hc );
+    m_filter8xH[0][isLast]( clpRng, src, srcStride, dst, dstStride, 8, height, vc, hc );
   }
   else if( vFilterSize == 4 )
   {
@@ -705,11 +705,11 @@ void InterpolationFilter::filter8x8( const ComponentID compID, const Pel* src, c
     const int csx = getComponentScaleX( compID, fmt );
     const int csy = getComponentScaleY( compID, fmt );
 
-    m_filter8x8[1][isLast]( clpRng, src, srcStride, dst, dstStride, 8, height, m_chromaFilter[fracX << ( 1 - csx )], m_chromaFilter[fracY << ( 1 - csy )] );
+    m_filter8xH[1][isLast]( clpRng, src, srcStride, dst, dstStride, 8, height, m_chromaFilter[fracX << ( 1 - csx )], m_chromaFilter[fracY << ( 1 - csy )] );
   }
 }
 
-void InterpolationFilter::filter16x16( const ComponentID compID, const Pel* src, const ptrdiff_t srcStride, Pel* dst, const ptrdiff_t dstStride, int width, int height, int fracX, int fracY, bool isLast, const ChromaFormat fmt, const ClpRng& clpRng, bool useAltHpelIf )
+void InterpolationFilter::filter16xH( const ComponentID compID, const Pel* src, const ptrdiff_t srcStride, Pel* dst, const ptrdiff_t dstStride, int width, int height, int fracX, int fracY, bool isLast, const ChromaFormat fmt, const ClpRng& clpRng, bool useAltHpelIf )
 {
   const int vFilterSize = isLuma( compID ) ? NTAPS_LUMA : NTAPS_CHROMA;
 
@@ -719,7 +719,7 @@ void InterpolationFilter::filter16x16( const ComponentID compID, const Pel* src,
     const TFilterCoeff* vc = ( fracX == 8 && useAltHpelIf ) ? m_lumaAltHpelIFilter : m_lumaFilter[fracX];
     const TFilterCoeff* hc = ( fracY == 8 && useAltHpelIf ) ? m_lumaAltHpelIFilter : m_lumaFilter[fracY];
 
-    m_filter16x16[0][isLast]( clpRng, src, srcStride, dst, dstStride, 16, height, vc, hc );
+    m_filter16xH[0][isLast]( clpRng, src, srcStride, dst, dstStride, 16, height, vc, hc );
   }
   else if( vFilterSize == 4 )
   {
@@ -728,13 +728,13 @@ void InterpolationFilter::filter16x16( const ComponentID compID, const Pel* src,
     const int csx = getComponentScaleX( compID, fmt );
     const int csy = getComponentScaleY( compID, fmt );
 
-    m_filter16x16[1][isLast]( clpRng, src, srcStride, dst, dstStride, 16, height, m_chromaFilter[fracX << ( 1 - csx )], m_chromaFilter[fracY << ( 1 - csy )] );
+    m_filter16xH[1][isLast]( clpRng, src, srcStride, dst, dstStride, 16, height, m_chromaFilter[fracX << ( 1 - csx )], m_chromaFilter[fracY << ( 1 - csy )] );
   }
 }
 
 
 template<bool isLast, int w>
-void InterpolationFilter::filterXxY_N2( const ClpRng& clpRng, const Pel* src, const ptrdiff_t srcStride, Pel* _dst, const ptrdiff_t dstStride, int width, int h, TFilterCoeff const *coeffH, TFilterCoeff const *coeffV )
+void InterpolationFilter::filterWxH_N2( const ClpRng& clpRng, const Pel* src, const ptrdiff_t srcStride, Pel* _dst, const ptrdiff_t dstStride, int width, int h, TFilterCoeff const *coeffH, TFilterCoeff const *coeffV )
 {
   int row, col;
 
@@ -802,7 +802,7 @@ void InterpolationFilter::filterXxY_N2( const ClpRng& clpRng, const Pel* src, co
 
 
 template<bool isLast, int w>
-void InterpolationFilter::filterXxY_N4( const ClpRng& clpRng, const Pel* src, const ptrdiff_t srcStride, Pel* _dst, const ptrdiff_t dstStride, int width, int height, TFilterCoeff const *coeffH, TFilterCoeff const *coeffV )
+void InterpolationFilter::filterWxH_N4( const ClpRng& clpRng, const Pel* src, const ptrdiff_t srcStride, Pel* _dst, const ptrdiff_t dstStride, int width, int height, TFilterCoeff const *coeffH, TFilterCoeff const *coeffV )
 {
   int row, col;
 
@@ -878,7 +878,7 @@ void InterpolationFilter::filterXxY_N4( const ClpRng& clpRng, const Pel* src, co
 
 
 template<bool isLast, int w>
-void InterpolationFilter::filterXxY_N8( const ClpRng& clpRng, const Pel* src, const ptrdiff_t srcStride, Pel* _dst, const ptrdiff_t dstStride, int width, int h, TFilterCoeff const *coeffH, TFilterCoeff const *coeffV )
+void InterpolationFilter::filterWxH_N8( const ClpRng& clpRng, const Pel* src, const ptrdiff_t srcStride, Pel* _dst, const ptrdiff_t dstStride, int width, int h, TFilterCoeff const *coeffH, TFilterCoeff const *coeffV )
 {
   int row, col;
 

--- a/source/Lib/CommonLib/InterpolationFilter.h
+++ b/source/Lib/CommonLib/InterpolationFilter.h
@@ -97,11 +97,11 @@ public:
   void filterVer        (const ClpRng& clpRng, const Pel* src, const ptrdiff_t srcStride, Pel* dst, const ptrdiff_t dstStride, int width, int height, bool isFirst, bool isLast, TFilterCoeff const *coeff);
 
   template<bool isLast, int w>
-  static void filterXxY_N2     (const ClpRng& clpRng, const Pel* src, const ptrdiff_t srcStride, Pel* dst, const ptrdiff_t dstStride, int width, int height, TFilterCoeff const *coeffH, TFilterCoeff const *coeffV);
+  static void filterWxH_N2     (const ClpRng& clpRng, const Pel* src, const ptrdiff_t srcStride, Pel* dst, const ptrdiff_t dstStride, int width, int height, TFilterCoeff const *coeffH, TFilterCoeff const *coeffV);
   template<bool isLast, int w>
-  static void filterXxY_N4     (const ClpRng& clpRng, const Pel* src, const ptrdiff_t srcStride, Pel* dst, const ptrdiff_t dstStride, int width, int height, TFilterCoeff const *coeffH, TFilterCoeff const *coeffV);
+  static void filterWxH_N4     (const ClpRng& clpRng, const Pel* src, const ptrdiff_t srcStride, Pel* dst, const ptrdiff_t dstStride, int width, int height, TFilterCoeff const *coeffH, TFilterCoeff const *coeffV);
   template<bool isLast, int w>
-  static void filterXxY_N8     (const ClpRng& clpRng, const Pel* src, const ptrdiff_t srcStride, Pel* dst, const ptrdiff_t dstStride, int width, int height, TFilterCoeff const *coeffH, TFilterCoeff const *coeffV);
+  static void filterWxH_N8     (const ClpRng& clpRng, const Pel* src, const ptrdiff_t srcStride, Pel* dst, const ptrdiff_t dstStride, int width, int height, TFilterCoeff const *coeffH, TFilterCoeff const *coeffV);
 
   static void scalarFilterN2_2D(const ClpRng& clpRng, const Pel* src, const ptrdiff_t srcStride, Pel* dst, const ptrdiff_t dstStride, int width, int height, TFilterCoeff const *ch,     TFilterCoeff const *cv);
 
@@ -116,11 +116,11 @@ public:
   void( *m_filterN2_2D        )( const ClpRng& clpRng, const Pel* src, const ptrdiff_t srcStride, Pel* dst, const ptrdiff_t dstStride, int width, int height, TFilterCoeff const *ch, TFilterCoeff const *cv );
   void( *m_filterHor[3][2][2] )( const ClpRng& clpRng, const Pel* src, const ptrdiff_t srcStride, Pel* dst, const ptrdiff_t dstStride, int width, int height, TFilterCoeff const *coeff );
   void( *m_filterVer[3][2][2] )( const ClpRng& clpRng, const Pel* src, const ptrdiff_t srcStride, Pel* dst, const ptrdiff_t dstStride, int width, int height, TFilterCoeff const *coeff );
-  void( *m_filterCopy[2][2] )  ( const ClpRng& clpRng, const Pel* src, const ptrdiff_t srcStride, Pel* dst, const ptrdiff_t dstStride, int width, int height, bool biMCForDMVR );
-  void( *m_filter4x4  [2][2] ) ( const ClpRng& clpRng, const Pel* src, const ptrdiff_t srcStride, Pel* dst, const ptrdiff_t dstStride, int width, int height, TFilterCoeff const *coeffH, TFilterCoeff const *coeffV );
-  void( *m_filter8x8  [2][2] ) ( const ClpRng& clpRng, const Pel* src, const ptrdiff_t srcStride, Pel* dst, const ptrdiff_t dstStride, int width, int height, TFilterCoeff const *coeffH, TFilterCoeff const *coeffV );
-  void( *m_filter16x16[2][2] ) ( const ClpRng& clpRng, const Pel* src, const ptrdiff_t srcStride, Pel* dst, const ptrdiff_t dstStride, int width, int height, TFilterCoeff const *coeffH, TFilterCoeff const *coeffV );
-  void( *m_weightedGeoBlk )(const CodingUnit &cu, const uint32_t width, const uint32_t height, const ComponentID compIdx, const uint8_t splitDir, PelUnitBuf& predDst, PelUnitBuf& predSrc0, PelUnitBuf& predSrc1, const ClpRng& clpRng);
+  void( *m_filterCopy[2][2]   )( const ClpRng& clpRng, const Pel* src, const ptrdiff_t srcStride, Pel* dst, const ptrdiff_t dstStride, int width, int height, bool biMCForDMVR );
+  void( *m_filter4x4 [2][2]   )( const ClpRng& clpRng, const Pel* src, const ptrdiff_t srcStride, Pel* dst, const ptrdiff_t dstStride, int width, int height, TFilterCoeff const *coeffH, TFilterCoeff const *coeffV );
+  void( *m_filter8xH [2][2]   )( const ClpRng& clpRng, const Pel* src, const ptrdiff_t srcStride, Pel* dst, const ptrdiff_t dstStride, int width, int height, TFilterCoeff const *coeffH, TFilterCoeff const *coeffV );
+  void( *m_filter16xH[2][2]   )( const ClpRng& clpRng, const Pel* src, const ptrdiff_t srcStride, Pel* dst, const ptrdiff_t dstStride, int width, int height, TFilterCoeff const *coeffH, TFilterCoeff const *coeffV );
+  void( *m_weightedGeoBlk     )(const CodingUnit &cu, const uint32_t width, const uint32_t height, const ComponentID compIdx, const uint8_t splitDir, PelUnitBuf& predDst, PelUnitBuf& predSrc0, PelUnitBuf& predSrc1, const ClpRng& clpRng);
 
   void initInterpolationFilter( bool enable );
 
@@ -138,8 +138,8 @@ public:
 
   void filterN2_2D(const ComponentID compID, const Pel* src, const ptrdiff_t srcStride, Pel* dst, const ptrdiff_t dstStride, int width, int height, int fracX, int fracY, const ChromaFormat fmt, const ClpRng& clpRng);
   void filter4x4  (const ComponentID compID, const Pel* src, const ptrdiff_t srcStride, Pel* dst, const ptrdiff_t dstStride, int width, int height, int fracX, int fracY, bool isLast, const ChromaFormat fmt, const ClpRng& clpRng);
-  void filter8x8  (const ComponentID compID, const Pel* src, const ptrdiff_t srcStride, Pel* dst, const ptrdiff_t dstStride, int width, int height, int fracX, int fracY, bool isLast, const ChromaFormat fmt, const ClpRng& clpRng, bool useAltHpelIf = false);
-  void filter16x16(const ComponentID compID, const Pel* src, const ptrdiff_t srcStride, Pel* dst, const ptrdiff_t dstStride, int width, int height, int fracX, int fracY, bool isLast, const ChromaFormat fmt, const ClpRng& clpRng, bool useAltHpelIf = false);
+  void filter8xH  (const ComponentID compID, const Pel* src, const ptrdiff_t srcStride, Pel* dst, const ptrdiff_t dstStride, int width, int height, int fracX, int fracY, bool isLast, const ChromaFormat fmt, const ClpRng& clpRng, bool useAltHpelIf = false);
+  void filter16xH (const ComponentID compID, const Pel* src, const ptrdiff_t srcStride, Pel* dst, const ptrdiff_t dstStride, int width, int height, int fracX, int fracY, bool isLast, const ChromaFormat fmt, const ClpRng& clpRng, bool useAltHpelIf = false);
   void filterHor  (const ComponentID compID, const Pel* src, const ptrdiff_t srcStride, Pel* dst, const ptrdiff_t dstStride, int width, int height, int frac,               bool isLast, const ChromaFormat fmt, const ClpRng& clpRng, int nFilterIdx = 0, bool useAltHpelIf = false );
   void filterVer  (const ComponentID compID, const Pel* src, const ptrdiff_t srcStride, Pel* dst, const ptrdiff_t dstStride, int width, int height, int frac, bool isFirst, bool isLast, const ChromaFormat fmt, const ClpRng& clpRng, int nFilterIdx = 0, bool useAltHpelIf = false );
   static TFilterCoeff const * getChromaFilterTable(const int deltaFract) { return m_chromaFilter[deltaFract]; };

--- a/source/Lib/CommonLib/arm/neon/InterpolationFilter_neon.cpp
+++ b/source/Lib/CommonLib/arm/neon/InterpolationFilter_neon.cpp
@@ -135,7 +135,7 @@ static void simdInterpolateN2_2D_neon( const ClpRng& clpRng, const Pel* src, con
   }
 }
 
-static int16x4_t filter4xX_N8_neon( Pel const* src, int16x8_t ch, int32x4_t voffset1, int32x4_t invshift1st )
+static int16x4_t filter4x4_N8_neon( Pel const* src, int16x8_t ch, int32x4_t voffset1, int32x4_t invshift1st )
 {
   int16x8_t vsrca0 = vld1q_s16( src + 0 );
   int16x8_t vsrca1 = vld1q_s16( src + 1 );
@@ -158,22 +158,22 @@ static int16x4_t filter4xX_N8_neon( Pel const* src, int16x8_t ch, int32x4_t voff
   return vqmovn_s32( vsuma );
 }
 
-static int16x8_t filter8xX_N8_neon( Pel const* src, int16x8_t ch, int32x4_t voffset1, int32x4_t invshift1st )
+static int16x8_t filter8xH_N8_neon( Pel const* src, int16x8_t ch, int32x4_t voffset1, int32x4_t invshift1st )
 {
-  int16x4_t lo = filter4xX_N8_neon( src + 0, ch, voffset1, invshift1st );
-  int16x4_t hi = filter4xX_N8_neon( src + 4, ch, voffset1, invshift1st );
+  int16x4_t lo = filter4x4_N8_neon( src + 0, ch, voffset1, invshift1st );
+  int16x4_t hi = filter4x4_N8_neon( src + 4, ch, voffset1, invshift1st );
   return vcombine_s16( lo, hi );
 }
 
-static int16x8x2_t filter16xX_N8_neon( Pel const* src, int16x8_t ch, int32x4_t voffset1, int32x4_t invshift1st )
+static int16x8x2_t filter16xH_N8_neon( Pel const* src, int16x8_t ch, int32x4_t voffset1, int32x4_t invshift1st )
 {
-  int16x8_t a = filter8xX_N8_neon( src + 0, ch, voffset1, invshift1st );
-  int16x8_t b = filter8xX_N8_neon( src + 8, ch, voffset1, invshift1st );
+  int16x8_t a = filter8xH_N8_neon( src + 0, ch, voffset1, invshift1st );
+  int16x8_t b = filter8xH_N8_neon( src + 8, ch, voffset1, invshift1st );
   return int16x8x2_t({ a, b });
 }
 
 template<bool isLast>
-static void simdFilter4xX_N8_neon( const ClpRng& clpRng, Pel const* src, const ptrdiff_t srcStride, Pel* dst, const ptrdiff_t dstStride,
+static void simdFilter4x4_N8_neon( const ClpRng& clpRng, Pel const* src, const ptrdiff_t srcStride, Pel* dst, const ptrdiff_t dstStride,
                                    int width, int height, TFilterCoeff const* coeffH, TFilterCoeff const* coeffV )
 {
   OFFSET( src, srcStride, -3, -3 );
@@ -205,24 +205,24 @@ static void simdFilter4xX_N8_neon( const ClpRng& clpRng, Pel const* src, const p
   int32x4_t invshift1st = vdupq_n_s32( -shift1st );
   int32x4_t invshift2nd = vdupq_n_s32( -shift2nd );
 
-  int16x4_t vsrcv0 = filter4xX_N8_neon( src, ch, voffset1, invshift1st );
+  int16x4_t vsrcv0 = filter4x4_N8_neon( src, ch, voffset1, invshift1st );
   src += srcStride;
-  int16x4_t vsrcv1 = filter4xX_N8_neon( src, ch, voffset1, invshift1st );
+  int16x4_t vsrcv1 = filter4x4_N8_neon( src, ch, voffset1, invshift1st );
   src += srcStride;
-  int16x4_t vsrcv2 = filter4xX_N8_neon( src, ch, voffset1, invshift1st );
+  int16x4_t vsrcv2 = filter4x4_N8_neon( src, ch, voffset1, invshift1st );
   src += srcStride;
-  int16x4_t vsrcv3 = filter4xX_N8_neon( src, ch, voffset1, invshift1st );
+  int16x4_t vsrcv3 = filter4x4_N8_neon( src, ch, voffset1, invshift1st );
   src += srcStride;
-  int16x4_t vsrcv4 = filter4xX_N8_neon( src, ch, voffset1, invshift1st );
+  int16x4_t vsrcv4 = filter4x4_N8_neon( src, ch, voffset1, invshift1st );
   src += srcStride;
-  int16x4_t vsrcv5 = filter4xX_N8_neon( src, ch, voffset1, invshift1st );
+  int16x4_t vsrcv5 = filter4x4_N8_neon( src, ch, voffset1, invshift1st );
   src += srcStride;
-  int16x4_t vsrcv6 = filter4xX_N8_neon( src, ch, voffset1, invshift1st );
+  int16x4_t vsrcv6 = filter4x4_N8_neon( src, ch, voffset1, invshift1st );
   src += srcStride;
 
   do
   {
-    int16x4_t vsrcv7 = filter4xX_N8_neon( src, ch, voffset1, invshift1st );
+    int16x4_t vsrcv7 = filter4x4_N8_neon( src, ch, voffset1, invshift1st );
     src += srcStride;
 
     int32x4_t vsum0 = vdupq_n_s32( offset2nd );
@@ -260,7 +260,7 @@ static void simdFilter4xX_N8_neon( const ClpRng& clpRng, Pel const* src, const p
 }
 
 template<bool isLast>
-static void simdFilter8xX_N8_neon( const ClpRng& clpRng, Pel const* src, const ptrdiff_t srcStride, Pel* dst, const ptrdiff_t dstStride,
+static void simdFilter8xH_N8_neon( const ClpRng& clpRng, Pel const* src, const ptrdiff_t srcStride, Pel* dst, const ptrdiff_t dstStride,
                                    int width, int height, TFilterCoeff const* coeffH, TFilterCoeff const* coeffV )
 {
   OFFSET( src, srcStride, -3, -3 );
@@ -292,24 +292,24 @@ static void simdFilter8xX_N8_neon( const ClpRng& clpRng, Pel const* src, const p
   int32x4_t invshift1st = vdupq_n_s32( -shift1st );
   int32x4_t invshift2nd = vdupq_n_s32( -shift2nd );
 
-  int16x8_t vsrcv0 = filter8xX_N8_neon( src, ch, voffset1, invshift1st );
+  int16x8_t vsrcv0 = filter8xH_N8_neon( src, ch, voffset1, invshift1st );
   src += srcStride;
-  int16x8_t vsrcv1 = filter8xX_N8_neon( src, ch, voffset1, invshift1st );
+  int16x8_t vsrcv1 = filter8xH_N8_neon( src, ch, voffset1, invshift1st );
   src += srcStride;
-  int16x8_t vsrcv2 = filter8xX_N8_neon( src, ch, voffset1, invshift1st );
+  int16x8_t vsrcv2 = filter8xH_N8_neon( src, ch, voffset1, invshift1st );
   src += srcStride;
-  int16x8_t vsrcv3 = filter8xX_N8_neon( src, ch, voffset1, invshift1st );
+  int16x8_t vsrcv3 = filter8xH_N8_neon( src, ch, voffset1, invshift1st );
   src += srcStride;
-  int16x8_t vsrcv4 = filter8xX_N8_neon( src, ch, voffset1, invshift1st );
+  int16x8_t vsrcv4 = filter8xH_N8_neon( src, ch, voffset1, invshift1st );
   src += srcStride;
-  int16x8_t vsrcv5 = filter8xX_N8_neon( src, ch, voffset1, invshift1st );
+  int16x8_t vsrcv5 = filter8xH_N8_neon( src, ch, voffset1, invshift1st );
   src += srcStride;
-  int16x8_t vsrcv6 = filter8xX_N8_neon( src, ch, voffset1, invshift1st );
+  int16x8_t vsrcv6 = filter8xH_N8_neon( src, ch, voffset1, invshift1st );
   src += srcStride;
 
   do
   {
-    int16x8_t vsrcv7 = filter8xX_N8_neon( src, ch, voffset1, invshift1st );
+    int16x8_t vsrcv7 = filter8xH_N8_neon( src, ch, voffset1, invshift1st );
     src += srcStride;
 
     int32x4_t vsum0 = vdupq_n_s32( offset2nd );
@@ -367,7 +367,7 @@ static void simdFilter8xX_N8_neon( const ClpRng& clpRng, Pel const* src, const p
 }
 
 template<bool isLast>
-static void simdFilter16xX_N8_neon( const ClpRng& clpRng, Pel const* src, const ptrdiff_t srcStride, Pel* dst, const ptrdiff_t dstStride,
+static void simdFilter16xH_N8_neon( const ClpRng& clpRng, Pel const* src, const ptrdiff_t srcStride, Pel* dst, const ptrdiff_t dstStride,
                                     int width, int height, TFilterCoeff const* coeffH, TFilterCoeff const* coeffV )
 {
   OFFSET( src, srcStride, -3, -3 );
@@ -399,24 +399,24 @@ static void simdFilter16xX_N8_neon( const ClpRng& clpRng, Pel const* src, const 
   int32x4_t invshift1st = vdupq_n_s32( -shift1st );
   int32x4_t invshift2nd = vdupq_n_s32( -shift2nd );
 
-  int16x8x2_t vsrcv0 = filter16xX_N8_neon( src, ch, voffset1, invshift1st );
+  int16x8x2_t vsrcv0 = filter16xH_N8_neon( src, ch, voffset1, invshift1st );
   src += srcStride;
-  int16x8x2_t vsrcv1 = filter16xX_N8_neon( src, ch, voffset1, invshift1st );
+  int16x8x2_t vsrcv1 = filter16xH_N8_neon( src, ch, voffset1, invshift1st );
   src += srcStride;
-  int16x8x2_t vsrcv2 = filter16xX_N8_neon( src, ch, voffset1, invshift1st );
+  int16x8x2_t vsrcv2 = filter16xH_N8_neon( src, ch, voffset1, invshift1st );
   src += srcStride;
-  int16x8x2_t vsrcv3 = filter16xX_N8_neon( src, ch, voffset1, invshift1st );
+  int16x8x2_t vsrcv3 = filter16xH_N8_neon( src, ch, voffset1, invshift1st );
   src += srcStride;
-  int16x8x2_t vsrcv4 = filter16xX_N8_neon( src, ch, voffset1, invshift1st );
+  int16x8x2_t vsrcv4 = filter16xH_N8_neon( src, ch, voffset1, invshift1st );
   src += srcStride;
-  int16x8x2_t vsrcv5 = filter16xX_N8_neon( src, ch, voffset1, invshift1st );
+  int16x8x2_t vsrcv5 = filter16xH_N8_neon( src, ch, voffset1, invshift1st );
   src += srcStride;
-  int16x8x2_t vsrcv6 = filter16xX_N8_neon( src, ch, voffset1, invshift1st );
+  int16x8x2_t vsrcv6 = filter16xH_N8_neon( src, ch, voffset1, invshift1st );
   src += srcStride;
 
   do
   {
-    int16x8x2_t vsrcv7 = filter16xX_N8_neon( src, ch, voffset1, invshift1st );
+    int16x8x2_t vsrcv7 = filter16xH_N8_neon( src, ch, voffset1, invshift1st );
     src += srcStride;
 
     int32x4_t vsum0 = vdupq_n_s32( offset2nd );
@@ -501,14 +501,14 @@ static void simdFilter16xX_N8_neon( const ClpRng& clpRng, Pel const* src, const 
 template<>
 void InterpolationFilter::_initInterpolationFilterARM<NEON>()
 {
-  m_filter4x4[ 0 ][ 0 ] = simdFilter4xX_N8_neon<false>;
-  m_filter4x4[ 0 ][ 1 ] = simdFilter4xX_N8_neon<true>;
+  m_filter4x4[0][0]  = simdFilter4x4_N8_neon<false>;
+  m_filter4x4[0][1]  = simdFilter4x4_N8_neon<true>;
 
-  m_filter8x8[ 0 ][ 0 ] = simdFilter8xX_N8_neon<false>;
-  m_filter8x8[ 0 ][ 1 ] = simdFilter8xX_N8_neon<true>;
+  m_filter8xH[0][0]  = simdFilter8xH_N8_neon<false>;
+  m_filter8xH[0][1]  = simdFilter8xH_N8_neon<true>;
 
-  m_filter16x16[ 0 ][ 0 ] = simdFilter16xX_N8_neon<false>;
-  m_filter16x16[ 0 ][ 1 ] = simdFilter16xX_N8_neon<true>;
+  m_filter16xH[0][0] = simdFilter16xH_N8_neon<false>;
+  m_filter16xH[0][1] = simdFilter16xH_N8_neon<true>;
 
   m_filterN2_2D = simdInterpolateN2_2D_neon;
 }

--- a/source/Lib/CommonLib/x86/InterpolationFilterX86.h
+++ b/source/Lib/CommonLib/x86/InterpolationFilterX86.h
@@ -2285,7 +2285,7 @@ skip_last_line_4x4_simd_N4:
 }
 
 template<X86_VEXT vext, bool isLast>
-void simdFilter16xX_N8( const ClpRng& clpRng, const Pel* src, const ptrdiff_t srcStride, Pel* dst, const ptrdiff_t dstStride, int width, int height, TFilterCoeff const *coeffH, TFilterCoeff const *coeffV )
+void simdFilter16xH_N8( const ClpRng& clpRng, const Pel* src, const ptrdiff_t srcStride, Pel* dst, const ptrdiff_t dstStride, int width, int height, TFilterCoeff const *coeffH, TFilterCoeff const *coeffV )
 {
   OFFSET( src, srcStride, -3, -3 );
 
@@ -2559,7 +2559,7 @@ void simdFilter16xX_N8( const ClpRng& clpRng, const Pel* src, const ptrdiff_t sr
 }
 
 template<X86_VEXT vext, bool isLast>
-void simdFilter16xX_N4( const ClpRng& clpRng, const Pel* src, const ptrdiff_t srcStride, Pel* dst, const ptrdiff_t dstStride, int width, int height, TFilterCoeff const *coeffH, TFilterCoeff const *coeffV )
+void simdFilter16xH_N4( const ClpRng& clpRng, const Pel* src, const ptrdiff_t srcStride, Pel* dst, const ptrdiff_t dstStride, int width, int height, TFilterCoeff const *coeffH, TFilterCoeff const *coeffV )
 {
   OFFSET( src, srcStride, -1, -1 );
 
@@ -2605,7 +2605,7 @@ void simdFilter16xX_N4( const ClpRng& clpRng, const Pel* src, const ptrdiff_t sr
 }
 
 template<X86_VEXT vext, bool isLast>
-void simdFilter8xX_N8( const ClpRng& clpRng, const Pel* src, const ptrdiff_t srcStride, Pel* dst, const ptrdiff_t dstStride, int width, int height, TFilterCoeff const *coeffH, TFilterCoeff const *coeffV )
+void simdFilter8xH_N8( const ClpRng& clpRng, const Pel* src, const ptrdiff_t srcStride, Pel* dst, const ptrdiff_t dstStride, int width, int height, TFilterCoeff const *coeffH, TFilterCoeff const *coeffV )
 {
   OFFSET( src, srcStride, -3, -3 );
 
@@ -2841,7 +2841,7 @@ void simdFilter8xX_N8( const ClpRng& clpRng, const Pel* src, const ptrdiff_t src
 }
 
 template<X86_VEXT vext, bool isLast>
-void simdFilter8xX_N4( const ClpRng& clpRng, const Pel* src, const ptrdiff_t srcStride, Pel* dst, const ptrdiff_t dstStride, int width, int height, TFilterCoeff const *coeffH, TFilterCoeff const *coeffV )
+void simdFilter8xH_N4( const ClpRng& clpRng, const Pel* src, const ptrdiff_t srcStride, Pel* dst, const ptrdiff_t dstStride, int width, int height, TFilterCoeff const *coeffH, TFilterCoeff const *coeffV )
 {
   OFFSET( src, srcStride, -1, -1 );
 
@@ -3366,17 +3366,17 @@ void InterpolationFilter::_initInterpolationFilterX86()
   m_filter4x4[1][0]    = simdFilter4x4_N4<vext, false>;
   m_filter4x4[1][1]    = simdFilter4x4_N4<vext, true>;
 
-  m_filter8x8[0][0]    = simdFilter8xX_N8<vext, false>;
-  m_filter8x8[0][1]    = simdFilter8xX_N8<vext, true>;
+  m_filter8xH[0][0]    = simdFilter8xH_N8<vext, false>;
+  m_filter8xH[0][1]    = simdFilter8xH_N8<vext, true>;
 
-  m_filter8x8[1][0]    = simdFilter8xX_N4<vext, false>;
-  m_filter8x8[1][1]    = simdFilter8xX_N4<vext, true>;
+  m_filter8xH[1][0]    = simdFilter8xH_N4<vext, false>;
+  m_filter8xH[1][1]    = simdFilter8xH_N4<vext, true>;
 
-  m_filter16x16[0][0]    = simdFilter16xX_N8<vext, false>;
-  m_filter16x16[0][1]    = simdFilter16xX_N8<vext, true>;
+  m_filter16xH[0][0]   = simdFilter16xH_N8<vext, false>;
+  m_filter16xH[0][1]   = simdFilter16xH_N8<vext, true>;
 
-  m_filter16x16[1][0]    = simdFilter16xX_N4<vext, false>;
-  m_filter16x16[1][1]    = simdFilter16xX_N4<vext, true>;
+  m_filter16xH[1][0]   = simdFilter16xH_N4<vext, false>;
+  m_filter16xH[1][1]   = simdFilter16xH_N4<vext, true>;
 
   m_filterN2_2D = simdInterpolateN2_2D<vext>;
 


### PR DESCRIPTION
Replace XxY with WxH to reflect width and height more explicitly, improving code readability and consistency with common dimension notation.

Also replace 8x8 and 16x16 with 8xH and 16xH, respectively, to indicate that they process inputs of varying heights.

This patch should now match the naming scheme implemented in VVenC.