### PR TITLE
Add unit tests for InterpolationFilter::filterWxH_N8

### DIFF
--- a/source/Lib/CommonLib/InterpolationFilter.h
+++ b/source/Lib/CommonLib/InterpolationFilter.h
@@ -72,8 +72,8 @@ using namespace arm_simd;
  */
 class InterpolationFilter
 {
-  static const TFilterCoeff m_lumaFilter4x4       [LUMA_INTERPOLATION_FILTER_SUB_SAMPLE_POSITIONS]  [NTAPS_LUMA];
 public:
+  static const TFilterCoeff m_lumaFilter4x4       [LUMA_INTERPOLATION_FILTER_SUB_SAMPLE_POSITIONS]  [NTAPS_LUMA];
   static const TFilterCoeff m_lumaFilter          [LUMA_INTERPOLATION_FILTER_SUB_SAMPLE_POSITIONS]  [NTAPS_LUMA]; ///< Luma filter taps
   static const TFilterCoeff m_chromaFilter        [CHROMA_INTERPOLATION_FILTER_SUB_SAMPLE_POSITIONS][NTAPS_CHROMA]; ///< Chroma filter taps
   static const TFilterCoeff m_lumaFilterRPR1      [LUMA_INTERPOLATION_FILTER_SUB_SAMPLE_POSITIONS]  [NTAPS_LUMA]; ///< Luma filter taps 1.5x
@@ -82,8 +82,8 @@ public:
   static const TFilterCoeff m_chromaFilterRPR2    [CHROMA_INTERPOLATION_FILTER_SUB_SAMPLE_POSITIONS][NTAPS_CHROMA]; ///< Chroma filter taps 2x
   static const TFilterCoeff m_affineLumaFilterRPR1[LUMA_INTERPOLATION_FILTER_SUB_SAMPLE_POSITIONS]  [NTAPS_LUMA]; ///< Luma filter taps 1.5x
   static const TFilterCoeff m_affineLumaFilterRPR2[LUMA_INTERPOLATION_FILTER_SUB_SAMPLE_POSITIONS]  [NTAPS_LUMA]; ///< Luma filter taps 2x
-private:
   static const TFilterCoeff m_lumaAltHpelIFilter                                                    [NTAPS_LUMA]; ///< Luma filter taps
+private:
   static const TFilterCoeff m_bilinearFilter      [LUMA_INTERPOLATION_FILTER_SUB_SAMPLE_POSITIONS]  [NTAPS_BILINEAR]; ///< bilinear filter taps
   static const TFilterCoeff m_bilinearFilterPrec4 [LUMA_INTERPOLATION_FILTER_SUB_SAMPLE_POSITIONS]  [NTAPS_BILINEAR]; ///< bilinear filter taps
 public:


### PR DESCRIPTION
Port unit tests from VVenC for the WxH luma 8-tap filters:
- filter4x4_N8
- filter8xH_N8
- filter16xH_N8

These tests run for both the isLast = {false, true} conditions.

Also make the filter coefficients public so they can be referenced in the unit tests.