### PR TITLE
Suppress non-trivial memcall warnings in Clang and GCC

### DIFF
--- a/source/Lib/CommonLib/Buffer.h
+++ b/source/Lib/CommonLib/Buffer.h
@@ -342,7 +342,7 @@ void AreaBuf<T>::fill(const T &val)
   {
     if( width == stride )
     {
-      ::memset( buf, 0, width * height * sizeof( T ) );
+      ::memset( ( void* )buf, 0, width * height * sizeof( T ) );
     }
     else
     {
@@ -351,7 +351,7 @@ void AreaBuf<T>::fill(const T &val)
 
       for( unsigned y = 0; y < height; y++ )
       {
-        ::memset( dest, 0, line );
+        ::memset( ( void* )dest, 0, line );
 
         dest += stride;
       }
@@ -378,10 +378,9 @@ void AreaBuf<T>::fill(const T &val)
 template<typename T>
 void AreaBuf<T>::memset( const int val )
 {
-  GCC_WARNING_DISABLE_class_memaccess
   if( width == stride )
   {
-    ::memset( buf, val, width * height * sizeof( T ) );
+    ::memset( ( void* )buf, val, width * height * sizeof( T ) );
   }
   else
   {
@@ -390,12 +389,11 @@ void AreaBuf<T>::memset( const int val )
 
     for( int y = 0; y < height; y++ )
     {
-      ::memset( dest, val, line );
+      ::memset( ( void* )dest, val, line );
 
       dest += stride;
     }
   }
-  GCC_WARNING_RESET
 }
 
 #if ENABLE_SIMD_OPT_BUFFER

--- a/source/Lib/CommonLib/CodingStructure.cpp
+++ b/source/Lib/CommonLib/CodingStructure.cpp
@@ -46,6 +46,7 @@ POSSIBILITY OF SUCH DAMAGE.
 
 #include "CodingStructure.h"
 
+#include <cstring>
 #include "Unit.h"
 #include "Slice.h"
 #include "Picture.h"
@@ -122,9 +123,7 @@ CodingUnit& CodingStructure::addCU( const UnitArea &unit, const ChannelType chTy
 {
   CodingUnit *cu = m_cuCache.get();
 
-  GCC_WARNING_DISABLE_class_memaccess
-  memset( cu, 0, sizeof( CodingUnit ) );
-  GCC_WARNING_RESET
+  memset( ( void* )cu, 0, sizeof( CodingUnit ) );
 
   cu->minInit    ( unit );
   cu->cs         = this;
@@ -210,9 +209,7 @@ TransformUnit& CodingStructure::addTU( const UnitArea &unit, const ChannelType c
   {
     tu = m_tuCache.get();
 
-    GCC_WARNING_DISABLE_class_memaccess
-    memset( tu, 0, sizeof( TransformUnit ) );
-    GCC_WARNING_RESET
+    memset( ( void* )tu, 0, sizeof( TransformUnit ) );
 
     cu.lastTU->next = tu;
     cu.lastTU       = tu;
@@ -334,11 +331,9 @@ void CodingStructure::initStructData()
   m_ctuWidthLog2[0] = pcv->maxCUWidthLog2 - unitScale[CH_L].posx;
   m_ctuWidthLog2[1] = m_ctuWidthLog2[0]; // same for luma and chroma, because of the 2x2 blocks
 
-  GCC_WARNING_DISABLE_class_memaccess
-  memset( m_ctuData,             0, sizeof( CtuData             ) * m_ctuDataSize );
-  memset( m_cuMap,               0, sizeof( CodingUnit*         ) * m_cuMapSize );
-  memset( m_colMiMap, CO_NOT_VALID, sizeof( ColocatedMotionInfo ) * m_colMiMapSize );
-  GCC_WARNING_RESET
+  memset( ( void* )m_ctuData,             0, sizeof( CtuData             ) * m_ctuDataSize  );
+  memset( ( void* )m_cuMap,               0, sizeof( CodingUnit*         ) * m_cuMapSize    );
+  memset( ( void* )m_colMiMap, CO_NOT_VALID, sizeof( ColocatedMotionInfo ) * m_colMiMapSize );
 
   const ptrdiff_t ctuSampleSizeL  = pcv->maxCUHeight * pcv->maxCUWidth;
   const ptrdiff_t ctuSampleSizeC  = isChromaEnabled( pcv->chrFormat ) ? ( ctuSampleSizeL >> ( getChannelTypeScaleX( CH_C, pcv->chrFormat) + getChannelTypeScaleY( CH_C, pcv->chrFormat ) ) ) : 0;

--- a/source/Lib/CommonLib/CommonDef.h
+++ b/source/Lib/CommonLib/CommonDef.h
@@ -107,10 +107,8 @@ POSSIBILITY OF SUCH DAMAGE.
 
 #if __GNUC__ >= 8 && !defined __clang__
 # define GCC_WARNING_DISABLE_maybe_uninitialized _Pragma("GCC diagnostic push"); _Pragma("GCC diagnostic ignored \"-Wmaybe-uninitialized\"");
-# define GCC_WARNING_DISABLE_class_memaccess     _Pragma("GCC diagnostic push"); _Pragma("GCC diagnostic ignored \"-Wclass-memaccess\"");
 #else
 # define GCC_WARNING_DISABLE_maybe_uninitialized
-# define GCC_WARNING_DISABLE_class_memaccess
 #endif
 
 #define CLASS_COPY_MOVE_DEFAULT( Class )      \

--- a/source/Lib/CommonLib/InterPrediction.cpp
+++ b/source/Lib/CommonLib/InterPrediction.cpp
@@ -1005,9 +1005,7 @@ void InterPrediction::xPredAffineBlk( const ComponentID&        compID,
 
   if( isLuma( compID ) )
   {
-    GCC_WARNING_DISABLE_class_memaccess
-    memset( m_storedMv, 0, MVBUFFER_SIZE * ( g_miScaling.scaleVer( height ) >> chromaScaleY ) * sizeof( Mv ) );
-    GCC_WARNING_RESET
+    memset( ( void* )m_storedMv, 0, MVBUFFER_SIZE * ( g_miScaling.scaleVer( height ) >> chromaScaleY ) * sizeof( Mv ) );
   }
 
   bool enablePROF = ( sps.getUsePROF() ) && ( compID == COMPONENT_Y );

--- a/source/Lib/CommonLib/MotionInfo.h
+++ b/source/Lib/CommonLib/MotionInfo.h
@@ -182,9 +182,7 @@ struct ColocatedMotionInfo
                    offsetof( MotionInfo, miRefIdx ) == offsetof( ColocatedMotionInfo, coRefIdx ),
                    "MotionInfo and ColocatedMotionInfo require the same memory layout" );
 
-    GCC_WARNING_DISABLE_class_memaccess
-    memcpy( this, &rhs, sizeof( MotionInfo ) );
-    GCC_WARNING_RESET
+    memcpy( ( void* )this, &rhs, sizeof( MotionInfo ) );
 
     return *this;
   }

--- a/source/Lib/CommonLib/TypeDef.h
+++ b/source/Lib/CommonLib/TypeDef.h
@@ -1001,9 +1001,7 @@ struct AlfSliceParam
     static_assert( offsetof( AlfSliceParam, recostructMutex ) + sizeof( recostructMutex ) == sizeof( AlfSliceParam ), "recostructMutex must be last member" );
     static_assert( std::is_standard_layout<AlfSliceParam>::value, "AlfSliceParam must be standard layout type for offsetof to work" );
 
-    GCC_WARNING_DISABLE_class_memaccess
-      memset( this, 0, offsetof( AlfSliceParam, recostructMutex ) );
-    GCC_WARNING_RESET
+    std::memset( ( void* )this, 0, offsetof( AlfSliceParam, recostructMutex ) );
 
     numLumaFilters = 1;
     numAlternativesChroma = 1;
@@ -1011,9 +1009,7 @@ struct AlfSliceParam
 
   const AlfSliceParam& operator=( const AlfSliceParam& src )
   {
-    GCC_WARNING_DISABLE_class_memaccess
-      std::memcpy( this, &src, offsetof( AlfSliceParam, recostructMutex ) );
-    GCC_WARNING_RESET
+    std::memcpy( ( void* )this, &src, offsetof( AlfSliceParam, recostructMutex ) );
 
     return *this;
   }
@@ -1034,14 +1030,14 @@ struct CcAlfFilterParam
 
   void reset()
   {
-    std::memset( this, 0, sizeof( *this ) );
+    std::memset( ( void* )this, 0, sizeof( *this ) );
 
     ccAlfFilterCount[0] = ccAlfFilterCount[1] = MAX_NUM_CC_ALF_FILTERS;
   }
 
   const CcAlfFilterParam& operator=( const CcAlfFilterParam& src )
   {
-    std::memcpy( this, &src, sizeof( CcAlfFilterParam ) );
+    std::memcpy( ( void* )this, &src, sizeof( CcAlfFilterParam ) );
     return *this;
   }
 };

--- a/source/Lib/CommonLib/UnitTools.cpp
+++ b/source/Lib/CommonLib/UnitTools.cpp
@@ -2947,9 +2947,7 @@ bool PU::getInterMergeSubPuMvpCand(const CodingUnit &cu, AffineMergeCtx& mrgCtx,
       for( int x = puPos.x; x < puPos.x + puSize.width; x += puWidth, miLinePtr += g_miScaling.scaleHor( puWidth ) )
       {
         mi.miRefIdx[0] = mi.miRefIdx[1] = MI_NOT_VALID;
-        GCC_WARNING_DISABLE_class_memaccess
-        memset( mi.mv, 0, sizeof( mi.mv ) );
-        GCC_WARNING_RESET
+        memset( ( void* )mi.mv, 0, sizeof( mi.mv ) );
 
         Position colPos{ x + xOff, y + yOff };
 

--- a/source/Lib/DecoderLib/DecLibRecon.cpp
+++ b/source/Lib/DecoderLib/DecLibRecon.cpp
@@ -770,9 +770,7 @@ bool DecLibRecon::ctuTask( int tid, CtuTaskParam* param )
         }
         else
         {
-          GCC_WARNING_DISABLE_class_memaccess
-          memset( ctuData.motion, MI_NOT_VALID, sizeof( MotionInfo ) * cs.pcv->num4x4CtuBlks );
-          GCC_WARNING_RESET
+          memset( ( void* )ctuData.motion, MI_NOT_VALID, sizeof( MotionInfo ) * cs.pcv->num4x4CtuBlks );
         }
 
         thisCtuState = MIDER_cont;


### PR DESCRIPTION
Some calls operate on pointers to non-trivially copyable types, which triggers `-Wnontrivial-memcall` in Clang and `-Wclass-memaccess` in GCC.

To intentionally perform byte-wise initialization/copy in these sites, cast the destination pointer to `void*` to make that intent explicit and silence both warnings.

This was previously handled by the `GCC_WARNING_DISABLE_class_memaccess` macro for GCC, however this does not work for Clang. With the addition of the cast this is now unnecessary and is removed.