### PR TITLE
Add unit tests for AdaptiveLoopFilter::Filter7x7Blk

### DIFF
--- a/source/Lib/CommonLib/AdaptiveLoopFilter.cpp
+++ b/source/Lib/CommonLib/AdaptiveLoopFilter.cpp
@@ -59,7 +59,7 @@ namespace vvdec
 
 constexpr int AdaptiveLoopFilter::AlfNumClippingValues[];
 
-AdaptiveLoopFilter::AdaptiveLoopFilter()
+AdaptiveLoopFilter::AdaptiveLoopFilter( bool enableOpt )
 {
   m_deriveClassificationBlk = deriveClassificationBlk;
   m_filterCcAlf             = filterBlkCcAlf;
@@ -67,11 +67,14 @@ AdaptiveLoopFilter::AdaptiveLoopFilter()
   m_filter5x5Blk            = filterBlk<ALF_FILTER_5>;
   m_filter7x7Blk            = filterBlk<ALF_FILTER_7>;
 
+  if( enableOpt )
+  {
 #if ENABLE_SIMD_OPT_ALF
 # ifdef TARGET_SIMD_X86
-  initAdaptiveLoopFilterX86();
+    initAdaptiveLoopFilterX86();
 # endif
 #endif
+  }
 
   for( int filterSetIndex = 0; filterSetIndex < NUM_FIXED_FILTER_SETS; filterSetIndex++ )
   {

--- a/source/Lib/CommonLib/AdaptiveLoopFilter.h
+++ b/source/Lib/CommonLib/AdaptiveLoopFilter.h
@@ -101,7 +101,10 @@ public:
   static constexpr int m_ALF_UNUSED_CLASSIDX     = 255;
   static constexpr int m_ALF_UNUSED_TRANSPOSIDX  = 255;
 
-  AdaptiveLoopFilter();
+  static const Pel m_alfClippVls[3][MaxAlfNumClippingValues];
+  static const int m_fixedFilterSetCoeff[ALF_FIXED_FILTER_NUM][MAX_NUM_ALF_LUMA_COEFF];
+
+  AdaptiveLoopFilter( bool enableOpt = true );
   ~AdaptiveLoopFilter() {}
   void create( const PicHeader* picHeader, const SPS* sps, const PPS* pps, int numThreads, PelUnitBuf& unitBuf );
   void destroy();
@@ -119,6 +122,12 @@ public:
   static void reconstructCoeffAPSs( Slice& slice );
   static void reconstructCoeff    ( AlfSliceParam& alfSliceParam, ChannelType channel, const int inputBitDepth );
 
+  void ( *m_filter5x5Blk )( const AlfClassifier* classifier, const PelUnitBuf& recDst, const CPelUnitBuf& recSrc,
+                            const Area& blk, const ComponentID compId, const short* filterSet, const short* fClipSet,
+                            const ClpRng& clpRng, int vbCTUHeight, int vbPos );
+  void ( *m_filter7x7Blk )( const AlfClassifier* classifier, const PelUnitBuf& recDst, const CPelUnitBuf& recSrc,
+                            const Area& blk, const ComponentID compId, const short* filterSet, const short* fClipSet,
+                            const ClpRng& clpRng, int vbCTUHeight, int vbPos );
 protected:
 
   static void deriveClassificationBlk( AlfClassifier *classifier, const CPelBuf& srcLuma, const Area& blk, const int shift, int vbCTUHeight, int vbPos );
@@ -136,9 +145,6 @@ protected:
   void ( *m_filterCcAlfBoth )        ( const PelBuf& dstBufCb, const PelBuf& dstBufCr, const CPelUnitBuf &recSrc, const Area &blkDst,
                                       const Area &blkSrc, const int16_t* filterCoeffCb, const int16_t* filterCoeffCr,
                                       const ClpRngs &clpRngs, int vbCTUHeight, int vbPos );
-
-  void ( *m_filter5x5Blk )           ( const AlfClassifier *classifier, const PelUnitBuf &recDst, const CPelUnitBuf& recSrc, const Area& blk, const ComponentID compId, const short* filterSet, const short* fClipSet, const ClpRng& clpRng, int vbCTUHeight, int vbPos );
-  void ( *m_filter7x7Blk )           ( const AlfClassifier *classifier, const PelUnitBuf &recDst, const CPelUnitBuf& recSrc, const Area& blk, const ComponentID compId, const short* filterSet, const short* fClipSet, const ClpRng& clpRng, int vbCTUHeight, int vbPos );
 
 #if defined(TARGET_SIMD_X86)  && ENABLE_SIMD_OPT_ALF
   void initAdaptiveLoopFilterX86();
@@ -160,11 +166,9 @@ protected:
                                            int&        rasterSliceAlfPad
                                            );
 
-  static const int        m_fixedFilterSetCoeff   [ALF_FIXED_FILTER_NUM][MAX_NUM_ALF_LUMA_COEFF];
   static const int        m_classToFilterMapping  [NUM_FIXED_FILTER_SETS][MAX_NUM_ALF_CLASSES];
   short                   m_fixedFilterSetCoeffDec[NUM_FIXED_FILTER_SETS][MAX_NUM_ALF_TRANSPOSE_ID * MAX_NUM_ALF_CLASSES * MAX_NUM_ALF_LUMA_COEFF];
   short                   m_clipDefault                                  [MAX_NUM_ALF_TRANSPOSE_ID * MAX_NUM_ALF_CLASSES * MAX_NUM_ALF_LUMA_COEFF];
-  static const Pel        m_alfClippVls[3][MaxAlfNumClippingValues];
   std::vector<PelStorage> m_tempBuf;
   PelUnitBuf              m_alfBuf;
   int                     m_inputBitDepth      = 0;


### PR DESCRIPTION
- Add unit tests for AdaptiveLoopFilter::Filter7x7Blk.
- Modify the AdaptiveLoopFilter constructor to include a new 'enableOpt' parameter to create a reference object and an optimized object for testing.
- Move clip and coefficient tables from the protected to the public section of the class to enable unit test access.
- Move 'm_filter5x5Blk' and 'm_filter7x7Blk' from the protected to the public section of the class to enable unit test access.