### PR TITLE
Arm: Port filterWxH_N8 Neon improvements from VVenC

### DIFF
--- a/source/Lib/CommonLib/CommonDef.h
+++ b/source/Lib/CommonLib/CommonDef.h
@@ -58,6 +58,9 @@ POSSIBILITY OF SUCH DAMAGE.
 #if defined( __x86_64__ ) || defined( _M_X64 ) || defined( __i386__ ) || defined( __i386 ) || defined( _M_IX86 )
 # define REAL_TARGET_X86 1
 #elif defined( __aarch64__ ) || defined( _M_ARM64 ) || defined( __arm__ ) || defined( _M_ARM )
+# if defined( __aarch64__ ) || defined( _M_ARM64 )
+#  define REAL_TARGET_AARCH64 1
+# endif
 # define REAL_TARGET_ARM 1
 #elif defined( __wasm__ ) || defined( __wasm32__ )
 # define REAL_TARGET_WASM 1

--- a/source/Lib/CommonLib/arm/neon/sum_neon.h
+++ b/source/Lib/CommonLib/arm/neon/sum_neon.h
@@ -1,0 +1,88 @@
+/* -----------------------------------------------------------------------------
+The copyright in this software is being made available under the Clear BSD
+License, included below. No patent rights, trademark rights and/or
+other Intellectual Property Rights other than the copyrights concerning
+the Software are granted under this license.
+
+The Clear BSD License
+
+Copyright (c) 2019-2025, Fraunhofer-Gesellschaft zur Förderung der angewandten Forschung e.V. & The VVDeC Authors.
+All rights reserved.
+
+Redistribution and use in source and binary forms, with or without modification,
+are permitted (subject to the limitations in the disclaimer below) provided that
+the following conditions are met:
+
+     * Redistributions of source code must retain the above copyright notice,
+     this list of conditions and the following disclaimer.
+
+     * Redistributions in binary form must reproduce the above copyright
+     notice, this list of conditions and the following disclaimer in the
+     documentation and/or other materials provided with the distribution.
+
+     * Neither the name of the copyright holder nor the names of its
+     contributors may be used to endorse or promote products derived from this
+     software without specific prior written permission.
+
+NO EXPRESS OR IMPLIED LICENSES TO ANY PARTY'S PATENT RIGHTS ARE GRANTED BY
+THIS LICENSE. THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND
+CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A
+PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR
+CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR
+BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER
+IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+POSSIBILITY OF SUCH DAMAGE.
+
+
+------------------------------------------------------------------------------------------- */
+
+/** \file     sum_neon.h
+    \brief    Helper functions for adding across vectors
+*/
+
+#pragma once
+
+#include "CommonDef.h"
+
+#if defined( TARGET_SIMD_ARM )
+
+#include <arm_neon.h>
+
+namespace vvdec
+{
+
+static inline int horizontal_add_s32x4( const int32x4_t a )
+{
+#if REAL_TARGET_AARCH64
+  return vaddvq_s32( a );
+#else
+  const int64x2_t b = vpaddlq_s32( a );
+  const int32x2_t c = vadd_s32( vreinterpret_s32_s64( vget_low_s64( b ) ), vreinterpret_s32_s64( vget_high_s64( b ) ) );
+  return vget_lane_s32( c, 0 );
+#endif
+}
+
+static inline int32x4_t horizontal_add_4d_s32x4( const int32x4_t v0, const int32x4_t v1, const int32x4_t v2,
+                                                 const int32x4_t v3 )
+{
+#if REAL_TARGET_AARCH64
+  int32x4_t v01 = vpaddq_s32( v0, v1 );
+  int32x4_t v23 = vpaddq_s32( v2, v3 );
+  return vpaddq_s32( v01, v23 );
+#else
+  int32x4_t res = vdupq_n_s32( 0 );
+  res = vsetq_lane_s32( horizontal_add_s32x4( v0 ), res, 0 );
+  res = vsetq_lane_s32( horizontal_add_s32x4( v1 ), res, 1 );
+  res = vsetq_lane_s32( horizontal_add_s32x4( v2 ), res, 2 );
+  res = vsetq_lane_s32( horizontal_add_s32x4( v3 ), res, 3 );
+  return res;
+#endif
+}
+
+} // namespace vvdec
+
+#endif


### PR DESCRIPTION
Port the improvements from VVenC for the Interpolation `filterWxH_N8` listed as follows:

- filter4x4: Replace the 8-tap with 6-tap filter since the 0th and 7th coefficients are zeros.

- filter4x4: Unroll the horizontal filter calculation in the do-while loop to eliminate the loop-carried dependency of copying results to the next iteration, and fix the height loop to 4, as this is the only use case for this function.

- All taps: Replace the `max` calculation for the headRoom with a `CHECKD` instead to ensure headRoom >= 2.

- All taps: Replace `vqmovn` with `vqmovun` for `isLast == true` case to save a `vdup` + `vmax` instruction.

Also, enable Arm 32-bit for these kernels by adding helper functions to replace AArch64-exclusive intrinsics with their Armv7 counterparts.  To handle this automatically, introduce a new REAL_TARGET_AARCH64 macro to distinguish between 32-bit and 64-bit in new and existing Arm code.

Remove the `__ARM_ARCH >= 8` guard since the newer code works with both Arm 64-bit and 32-bit builds.

Performance uplift vs previous Neon:
  4x4 (6-tap): 1.40x
  8xH  (true): 1.07x
 16xH  (true): 1.02x

These benchmarks are taken from a Neoverse V2 using LLVM-21.