### PR TITLE
Pad Coeff and Clip buffers to 8 elements in ALF 5x5 unit_test

### DIFF
--- a/tests/vvdec_unit_test/vvdec_unit_test.cpp
+++ b/tests/vvdec_unit_test/vvdec_unit_test.cpp
@@ -286,7 +286,7 @@ static bool check_one_filterBlk( AdaptiveLoopFilter* ref, AdaptiveLoopFilter* op
 
     constexpr size_t numSampleChromaCoeff = 25;
     // Values taken from real codec runs.
-    short chromaCoeffs[numSampleChromaCoeff][MAX_NUM_ALF_CHROMA_COEFF] = {
+    short chromaCoeffs[numSampleChromaCoeff][MAX_NUM_ALF_CHROMA_COEFF + 1] = {
         { -11, 2, 20, 3, -9, 23 },   { -10, 11, 14, 15, 10, 18 }, { -5, 0, 11, 5, -2, -4 },
         { -3, 8, 9, 9, 0, -23 },     { -10, 2, 13, 0, 13, 24 },   { -8, -2, 10, 4, -8, 18 },
         { 2, 2, -14, 3, 5, -14 },    { 2, 2, -7, 2, 3, -5 },      { 3, 2, -11, 5, 6, -14 },
@@ -299,7 +299,7 @@ static bool check_one_filterBlk( AdaptiveLoopFilter* ref, AdaptiveLoopFilter* op
 
     short* chromaCoeff = chromaCoeffs[rng.get( 0, numSampleChromaCoeff - 1 )];
 
-    std::vector<short> chrmClip( MAX_NUM_ALF_CHROMA_COEFF );
+    std::vector<short> chrmClip( MAX_NUM_ALF_CHROMA_COEFF + 1, 0 );
     for( unsigned i = 0; i < MAX_NUM_ALF_CHROMA_COEFF; ++i )
     {
       auto clip_idx = rng.get( 0, AdaptiveLoopFilter::MaxAlfNumClippingValues - 1 );


### PR DESCRIPTION
Pad Coeff and Clip buffers to 8 elements in ALF 5x5 unit_test to prevent ASan overflow in simdFilter5x5Blk.

The overflow only occurs in the x86 path (simdFilter5x5Blk), which uses `_mm_loadu_si128((__m128i*)filterSet)` to load eight shorts even though `MAX_NUM_ALF_CHROMA_COEFF` is defined as seven. The same applies to the clip buffer. In the unit test, `filterSet` and `fClipSet` were 7-element vectors, so the eighth load causes ASan heap buffer overflow.

In the real decoder, the coefficient buffer comes from `AlfSliceParam::chromaCoeff` (and similarly `chromaClipp`), which is a 8×7 array inside the struct. When `altIdx == 7`, that extra load lands in the next slot (struct padding/next field), keeping it in-bounds within the struct's storage and thus never flagged at runtime.