### PR TITLE
Add unit tests for gradFilter

### DIFF
--- a/source/Lib/CommonLib/InterPrediction.cpp
+++ b/source/Lib/CommonLib/InterPrediction.cpp
@@ -320,9 +320,9 @@ void prefetchPadCore( const Pel* src, const ptrdiff_t srcStride, Pel* dst, const
 
 
 InterPrediction::InterPrediction()
-  : BiOptFlow     ( BiOptFlowCore )
-  , BioGradFilter ( gradFilterCore )
+  : BioGradFilter ( gradFilterCore )
   , profGradFilter( gradFilterCore<false> )
+  , BiOptFlow     ( BiOptFlowCore )
   , roundIntVector( nullptr )
 {
   clipMv = clipMvInPic;
@@ -340,7 +340,7 @@ void InterPrediction::destroy()
   m_IBCBuffer.destroy();
 }
 
-void InterPrediction::init( RdCost* pcRdCost, ChromaFormat chromaFormatIDC, const int ctuSize )
+void InterPrediction::init( RdCost* pcRdCost, ChromaFormat chromaFormatIDC, const int ctuSize, bool enableOpt )
 {
   m_pcRdCost = pcRdCost;
 
@@ -371,9 +371,12 @@ void InterPrediction::init( RdCost* pcRdCost, ChromaFormat chromaFormatIDC, cons
     prefetchPad[0] = prefetchPadCore<2>; // luma
     prefetchPad[1] = prefetchPadCore<2>; // chroma for 444 and 422
     prefetchPad[2] = prefetchPadCore<1>; // chroma for 420
+    if( enableOpt )
+    {
 #if ENABLE_SIMD_OPT_INTER && defined( TARGET_SIMD_X86 )
-    initInterPredictionX86();
+      initInterPredictionX86();
 #endif
+    }
   }
 
   if( m_IBCBuffer.bufs.empty() )

--- a/source/Lib/CommonLib/InterPrediction.h
+++ b/source/Lib/CommonLib/InterPrediction.h
@@ -73,6 +73,10 @@ class Mv;
 class InterPrediction : public WeightPrediction
 {
   friend class TrQuant; // for the access to the shared buffers m_acYuvPRed
+public:
+  void ( *BioGradFilter )  ( Pel* pSrc, ptrdiff_t srcStride, int width, int height, ptrdiff_t gradStride, Pel* gradX, Pel* gradY, const int bitDepth ) = nullptr;
+  void ( *profGradFilter ) ( Pel* pSrc, ptrdiff_t srcStride, int width, int height, ptrdiff_t gradStride, Pel* gradX, Pel* gradY, const int bitDepth );
+
 protected:
   InterpolationFilter  m_if;
 
@@ -138,14 +142,11 @@ protected:
                                   bool                  bilinearMC   = false,
                                   Pel*                  srcPadBuf    = NULL,
                                   ptrdiff_t             srcPadStride = 0 );
-
-  void (*BiOptFlow)             ( const Pel* srcY0,const Pel* srcY1,const Pel* gradX0,const Pel* gradX1,const Pel* gradY0,const Pel* gradY1,const int width,const int height,Pel* dstY,const ptrdiff_t dstStride,const int shiftNum,const int  offset,const int  limit, const ClpRng& clpRng, const int bitDepth ) = nullptr;
-  void (*BioGradFilter)         (       Pel* pSrc, ptrdiff_t srcStride,  int width, int height, ptrdiff_t gradStride, Pel* gradX, Pel* gradY, const int bitDepth ) = nullptr;
-
+  void ( *BiOptFlow )           ( const Pel* srcY0, const Pel* srcY1, const Pel* gradX0, const Pel* gradX1, const Pel* gradY0, const Pel* gradY1, const int width, const int height, Pel* dstY, const ptrdiff_t dstStride, const int shiftNum, const int offset, const int limit, const ClpRng& clpRng, const int bitDepth ) = nullptr;
+  
   void( *PaddBIO )              ( const Pel* refPel, Pel* dstPel, unsigned width, const int shift );
 
   void xWeightedAverage         ( const CodingUnit& cu, const PelUnitBuf& pcYuvSrc0, const PelUnitBuf& pcYuvSrc1, PelUnitBuf& pcYuvDst, const BitDepths& clipBitDepths, const ClpRngs& clpRngs, const bool& bioApplied );
-  void( *profGradFilter )       ( Pel* pSrc, ptrdiff_t srcStride, int width, int height, ptrdiff_t gradStride, Pel* gradX, Pel* gradY, const int bitDepth );
   void( *applyPROF[2] )         ( Pel* dst, ptrdiff_t dstStride, const Pel* src, const Pel* gradX, const Pel* gradY, const int* dMvX, const int* dMvY, int shiftNum, Pel offset, const ClpRng& clpRng );
   void( *roundIntVector )       ( int* v, int size, unsigned int nShift, const int dmvLimit );
   void( *clipMv )               ( Mv& rcMv, const Position& pos, const struct Size& size, const SPS& sps, const PPS& pps );
@@ -163,7 +164,7 @@ public:
   InterPrediction();
   virtual ~InterPrediction();
 
-  void    init                (RdCost* pcRdCost, ChromaFormat chromaFormatIDC, const int ctuSize);
+  void init                     ( RdCost* pcRdCost, ChromaFormat chromaFormatIDC, const int ctuSize, bool enableOpt = true );
 
   // inter
   void    motionCompensation  (CodingUnit &cu, PelUnitBuf& predBuf, const bool luma = true, const bool chroma = true);

--- a/tests/vvdec_unit_test/CMakeLists.txt
+++ b/tests/vvdec_unit_test/CMakeLists.txt
@@ -26,15 +26,17 @@ endif()
 
 target_include_directories( ${EXE_NAME}
   PRIVATE
-    ${VVDEC_LIB_DIR}
-    ${VVDEC_LIB_DIR}/CommonLib
+    "${VVDEC_LIB_DIR}"
+    "${VVDEC_LIB_DIR}/CommonLib"
+    "${VVDEC_LIB_DIR}/CommonLib/x86"
+    "${CMAKE_CURRENT_SOURCE_DIR}/../../thirdparty/"
 )
 
 target_link_libraries( ${EXE_NAME} Threads::Threads vvdec )
 
 target_compile_options( ${EXE_NAME} PRIVATE $<$<OR:$<CXX_COMPILER_ID:Clang>,$<CXX_COMPILER_ID:AppleClang>>:-Wall>
                                             $<$<CXX_COMPILER_ID:GNU>:-Wall -fdiagnostics-show-option -Wno-ignored-attributes -Wno-sign-compare>
-                                            $<$<CXX_COMPILER_ID:MSVC>:/W4 /WX /wd4244 /wd4251 /wd4996>)
+                                            $<$<CXX_COMPILER_ID:MSVC>:/W4 /WX /wd4244 /wd4251 /wd4996 /wd4189>)
 
 # example: place header files in different folders
 source_group( "Header Files"   FILES ${INC_FILES} )


### PR DESCRIPTION
Add gradFilter unit tests which compare the SIMD and C implementations. To make this possible, add an enableOpt parameter to vvdec::InterPrediction::init() that toggles SIMD optimizations, and change BioGradFilter and profGradFilter from protected to public so the tests can call them directly. The init()'s new parameter has a default value, so call sites do not have to be updated.