### PR TITLE
Add missing header for stdarg

### DIFF
--- a/include/vvdec/vvdec.h.in
+++ b/include/vvdec/vvdec.h.in
@@ -46,6 +46,7 @@ POSSIBILITY OF SUCH DAMAGE.
 
 #include <stdint.h>
 #include <stdbool.h>
+#include <stdarg.h>
 
 #include "vvdec/sei.h"
 


### PR DESCRIPTION
```
[ 83%] Building CXX object source/Lib/vvdec/CMakeFiles/vvdec.dir/vvdec.cpp.o
In file included from /home/brad/tmp/vvdec/source/Lib/vvdec/vvdec.cpp:42:
/home/brad/tmp/vvdec/build/vvdec/vvdec.h:84:63: error: unknown type name 'va_list'; did you mean '__va_list'?
   84 | typedef void (*vvdecLoggingCallback)(void*, int, const char*, va_list);
      |                                                               ^~~~~~~
      |                                                               __va_list
/usr/include/machine/_types.h:127:27: note: '__va_list' declared here
  127 | typedef __builtin_va_list       __va_list;
      |                                 ^
1 error generated.
```