### PR TITLE
GHActions: also run unit tests with ASAN

### DIFF
--- a/.github/workflows/Build.yml
+++ b/.github/workflows/Build.yml
@@ -100,6 +100,11 @@ jobs:
             compiler: [gcc-14, g++-14]
             run_unit_test: true
 
+          - name: "ubuntu-24.04 ASAN"
+            os: ubuntu-24.04
+            compiler: [gcc-14, g++-14]
+            run_unit_test: true
+            cxx_flags: "-fsanitize=address"
 
           - os: ubuntu-22.04
             compiler: [clang-13, clang++-13]
@@ -138,6 +143,8 @@ jobs:
       CMAKE_GENERATOR: "${{ matrix.generator || 'Ninja' }}"
       CC: ${{ matrix.compiler[0] }}
       CXX: ${{ matrix.compiler[1] }}
+      CFLAGS: ${{ matrix.cxx_flags }}
+      CXXFLAGS: ${{ matrix.cxx_flags }}
       CCACHE_DIR: ${{ github.workspace }}/.ccache
       CCACHE_MAXSIZE: 100M
     steps:

--- a/.github/workflows/Build.yml
+++ b/.github/workflows/Build.yml
@@ -100,7 +100,7 @@ jobs:
             compiler: [gcc-14, g++-14]
             run_unit_test: true
 
-          - name: "ubuntu-24.04 ASAN"
+          - name: "ubuntu-24.04 with ASAN"
             os: ubuntu-24.04
             compiler: [gcc-14, g++-14]
             run_unit_test: true
@@ -133,6 +133,13 @@ jobs:
           - os: ubuntu-24.04-arm
             compiler: [aarch64-linux-gnu-gcc, aarch64-linux-gnu-g++]
             install_packages: g++-aarch64-linux-gnu
+            run_unit_test: true
+
+          - name: "ubuntu-24.04-arm with ASAN"
+            os: ubuntu-24.04-arm
+            compiler: [aarch64-linux-gnu-gcc, aarch64-linux-gnu-g++]
+            install_packages: g++-aarch64-linux-gnu
+            cxx_flags: "-fsanitize=address"
             run_unit_test: true
 
           - os: ubuntu-24.04

--- a/.github/workflows/Build.yml
+++ b/.github/workflows/Build.yml
@@ -171,4 +171,4 @@ jobs:
       - uses: actions/cache/save@v5
         with:
           path: .ccache
-          key: ccache-{{ matrix.name || matrix.os }}-${{ matrix.compiler[1] || matrix.osx_arch }}
+          key: ccache-${{ matrix.name || matrix.os }}-${{ matrix.compiler[1] || matrix.osx_arch }}

--- a/.github/workflows/Build.yml
+++ b/.github/workflows/Build.yml
@@ -96,9 +96,10 @@ jobs:
           - os: ubuntu-24.04
             compiler: [gcc-13, g++-13]
 
-          - os: ubuntu-24.04
-            compiler: [gcc-14, g++-14]
-            run_unit_test: true
+# disabled, because we also run it with ASAN
+#          - os: ubuntu-24.04
+#            compiler: [gcc-14, g++-14]
+#            run_unit_test: true
 
           - name: "ubuntu-24.04 with ASAN"
             os: ubuntu-24.04
@@ -130,10 +131,11 @@ jobs:
 #          - os: ubuntu-24.04
 #            compiler: [clang-19, clang++-19]
 
-          - os: ubuntu-24.04-arm
-            compiler: [aarch64-linux-gnu-gcc, aarch64-linux-gnu-g++]
-            install_packages: g++-aarch64-linux-gnu
-            run_unit_test: true
+# disabled, because we also run it with ASAN
+#          - os: ubuntu-24.04-arm
+#            compiler: [aarch64-linux-gnu-gcc, aarch64-linux-gnu-g++]
+#            install_packages: g++-aarch64-linux-gnu
+#            run_unit_test: true
 
           - name: "ubuntu-24.04-arm with ASAN"
             os: ubuntu-24.04-arm


### PR DESCRIPTION
The tests currently fail due to multiple heap overflows in the vvdec_unit_tests.