### PR TITLE
fix undefined behavior: call through pointer to incorrect function type

### DIFF
--- a/source/Lib/DecoderLib/DecLibParser.cpp
+++ b/source/Lib/DecoderLib/DecLibParser.cpp
@@ -977,11 +977,12 @@ bool DecLibParser::xDecodeSliceMain( InputNALUnit& nalu )
 
   ITT_TASKEND( itt_domain_oth, itt_handle_start );
 
-  static const auto parseTask = []( int threadId, Slice* slice )
+  static const auto parseTask = []( int threadId, void* param )
   {
-    auto& decLib    = slice->parseTaskParams.decLibParser;
-    auto& bitstream = slice->parseTaskParams.bitstream;
-    auto* pic       = slice->getPic();
+    Slice* slice     = static_cast<Slice*>( param );
+    auto&  decLib    = slice->parseTaskParams.decLibParser;
+    auto&  bitstream = slice->parseTaskParams.bitstream;
+    auto*  pic       = slice->getPic();
 
     try
     {
@@ -1022,14 +1023,14 @@ bool DecLibParser::xDecodeSliceMain( InputNALUnit& nalu )
   {
     if( m_uiSliceSegmentIdx > 0 )
     {
-      m_threadPool->addBarrierTask<Slice>( TP_TASK_NAME_ARG( "POC:" + std::to_string( m_pcParsePic->poc ) + " parseTask" )
-                                           parseTask, pcSlice, &m_pcParsePic->m_divTasksCounter, &pcSlice->parseDone,
-                                           CBarrierVec{ &m_pcParsePic->slices[m_uiSliceSegmentIdx - 1]->parseDone } );
+      m_threadPool->addBarrierTask( TP_TASK_NAME_ARG( "POC:" + std::to_string( m_pcParsePic->poc ) + " parseTask" )
+                                    parseTask, pcSlice, &m_pcParsePic->m_divTasksCounter, &pcSlice->parseDone,
+                                    CBarrierVec{ &m_pcParsePic->slices[m_uiSliceSegmentIdx - 1]->parseDone } );
     }
     else
     {
-      m_threadPool->addBarrierTask<Slice>( TP_TASK_NAME_ARG( "POC:" + std::to_string( m_pcParsePic->poc ) + " parseTask" )
-                                           parseTask, pcSlice,  &m_pcParsePic->m_divTasksCounter, &pcSlice->parseDone );
+      m_threadPool->addBarrierTask( TP_TASK_NAME_ARG( "POC:" + std::to_string( m_pcParsePic->poc ) + " parseTask" )
+                                    parseTask, pcSlice,  &m_pcParsePic->m_divTasksCounter, &pcSlice->parseDone );
     }
   }
   else

--- a/source/Lib/DecoderLib/DecLibRecon.cpp
+++ b/source/Lib/DecoderLib/DecLibRecon.cpp
@@ -262,108 +262,122 @@ void DecLibRecon::borderExtPic( Picture* pic, const Picture* currPic )
   if( wrapAround )
   {
     // copy reconstruction buffer to wrapAround buffer. All other border-extension tasks depend on this task.
-    static auto copyTask = []( int, Picture* picture ) {
+    static auto copyTask = []( int, void* task_param )
+    {
       ITT_TASKSTART( itt_domain_dec, itt_handle_ext );
+      Picture* picture = static_cast<Picture*>( task_param );
       picture->getRecoBuf( true ).copyFrom( picture->getRecoBuf() );
       ITT_TASKEND( itt_domain_dec, itt_handle_ext );
       return true;
     };
     pic->m_copyWrapBufDone.lock();
-    m_decodeThreadPool->addBarrierTask<Picture>( TP_TASK_NAME_ARG( "POC:" + std::to_string( currPic->poc ) + " copyTask Ref-POC:" + std::to_string( pic->poc ) )
-                                                 copyTask,
-                                                 pic,
-                                                 &pic->m_borderExtTaskCounter,
-                                                 &pic->m_copyWrapBufDone,
-                                                 { &pic->reconDone } );
+    m_decodeThreadPool->addBarrierTask( TP_TASK_NAME_ARG( "POC:" + std::to_string( currPic->poc ) + " copyTask Ref-POC:" + std::to_string( pic->poc ) )
+                                        copyTask,
+                                        pic,
+                                        &pic->m_borderExtTaskCounter,
+                                        &pic->m_copyWrapBufDone,
+                                        { &pic->reconDone } );
   }
 
   // start actual border extension tasks
   {
-    static auto task = []( int, Picture* picture ) {
+    static auto task = []( int, void* task_param )
+    {
       ITT_TASKSTART( itt_domain_dec, itt_handle_ext );
+      Picture* picture = static_cast<Picture*>( task_param );
       picture->extendPicBorder( true, false, false, false );
       ITT_TASKEND( itt_domain_dec, itt_handle_ext );
       return true;
     };
-    m_decodeThreadPool->addBarrierTask<Picture>( TP_TASK_NAME_ARG( "POC:" + std::to_string(currPic->poc) + " borderExtTask T Ref-POC:" + std::to_string(pic->poc) )
-                                                 task,
-                                                 pic,
-                                                 &pic->m_borderExtTaskCounter,
-                                                 nullptr,
-                                                 { wrapAround ? &pic->m_copyWrapBufDone : &pic->reconDone } );
+    m_decodeThreadPool->addBarrierTask( TP_TASK_NAME_ARG( "POC:" + std::to_string(currPic->poc) + " borderExtTask T Ref-POC:" + std::to_string(pic->poc) )
+                                        task,
+                                        pic,
+                                        &pic->m_borderExtTaskCounter,
+                                        nullptr,
+                                        { wrapAround ? &pic->m_copyWrapBufDone : &pic->reconDone } );
   }
 
   {
-    static auto task = []( int, Picture* picture ) {
+    static auto task = []( int, void* task_param )
+    {
       ITT_TASKSTART( itt_domain_dec, itt_handle_ext );
+      Picture* picture = static_cast<Picture*>( task_param );
       picture->extendPicBorder( false, true, false, false );
       ITT_TASKEND( itt_domain_dec, itt_handle_ext );
       return true;
     };
-    m_decodeThreadPool->addBarrierTask<Picture>( TP_TASK_NAME_ARG( "POC:" + std::to_string(currPic->poc) + " borderExtTask B Ref-POC:" + std::to_string(pic->poc) )
-                                                 task,
-                                                 pic,
-                                                 &pic->m_borderExtTaskCounter,
-                                                 nullptr,
-                                                 { wrapAround ? &pic->m_copyWrapBufDone : &pic->reconDone } );
+    m_decodeThreadPool->addBarrierTask( TP_TASK_NAME_ARG( "POC:" + std::to_string(currPic->poc) + " borderExtTask B Ref-POC:" + std::to_string(pic->poc) )
+                                        task,
+                                        pic,
+                                        &pic->m_borderExtTaskCounter,
+                                        nullptr,
+                                        { wrapAround ? &pic->m_copyWrapBufDone : &pic->reconDone } );
   }
 
   {
-    static auto task = []( int, Picture* picture ) {
+    static auto task = []( int, void* task_param )
+    {
       ITT_TASKSTART( itt_domain_dec, itt_handle_ext );
+      Picture* picture = static_cast<Picture*>( task_param );
       picture->extendPicBorder( false, false, true, false, CH_L );
       ITT_TASKEND( itt_domain_dec, itt_handle_ext );
       return true;
     };
-    m_decodeThreadPool->addBarrierTask<Picture>( TP_TASK_NAME_ARG( "POC:" + std::to_string(currPic->poc) + " borderExtTask ltT Ref-POC:" + std::to_string(pic->poc) )
-                                                 task,
-                                                 pic,
-                                                 &pic->m_borderExtTaskCounter,
-                                                 nullptr,
-                                                 { wrapAround ? &pic->m_copyWrapBufDone : &pic->reconDone } );
+    m_decodeThreadPool->addBarrierTask( TP_TASK_NAME_ARG( "POC:" + std::to_string(currPic->poc) + " borderExtTask ltT Ref-POC:" + std::to_string(pic->poc) )
+                                        task,
+                                        pic,
+                                        &pic->m_borderExtTaskCounter,
+                                        nullptr,
+                                        { wrapAround ? &pic->m_copyWrapBufDone : &pic->reconDone } );
   }
   {
-    static auto task = []( int, Picture* picture ) {
+    static auto task = []( int, void* task_param )
+    {
       ITT_TASKSTART( itt_domain_dec, itt_handle_ext );
+      Picture* picture = static_cast<Picture*>( task_param );
       picture->extendPicBorder( false, false, false, true, CH_L );
       ITT_TASKEND( itt_domain_dec, itt_handle_ext );
       return true;
     };
-    m_decodeThreadPool->addBarrierTask<Picture>( TP_TASK_NAME_ARG( "POC:" + std::to_string(currPic->poc) + " borderExtTask lrB Y Ref-POC:" + std::to_string(pic->poc) )
-                                                 task,
-                                                 pic,
-                                                 &pic->m_borderExtTaskCounter,
-                                                 nullptr,
-                                                 { wrapAround ? &pic->m_copyWrapBufDone : &pic->reconDone } );
+    m_decodeThreadPool->addBarrierTask( TP_TASK_NAME_ARG( "POC:" + std::to_string(currPic->poc) + " borderExtTask lrB Y Ref-POC:" + std::to_string(pic->poc) )
+                                        task,
+                                        pic,
+                                        &pic->m_borderExtTaskCounter,
+                                        nullptr,
+                                        { wrapAround ? &pic->m_copyWrapBufDone : &pic->reconDone } );
   }
 
   {
-    static auto task = []( int, Picture* picture ) {
+    static auto task = []( int, void* task_param )
+    {
       ITT_TASKSTART( itt_domain_dec, itt_handle_ext );
+      Picture* picture = static_cast<Picture*>( task_param );
       picture->extendPicBorder( false, false, true, false, CH_C );
       ITT_TASKEND( itt_domain_dec, itt_handle_ext );
       return true;
     };
-    m_decodeThreadPool->addBarrierTask<Picture>( TP_TASK_NAME_ARG( "POC:" + std::to_string(currPic->poc) + " borderExtTask lrB UV Ref-POC:" + std::to_string(pic->poc) )
-                                                 task,
-                                                 pic,
-                                                 &pic->m_borderExtTaskCounter,
-                                                 nullptr,
-                                                 { wrapAround ? &pic->m_copyWrapBufDone : &pic->reconDone } );
+    m_decodeThreadPool->addBarrierTask( TP_TASK_NAME_ARG( "POC:" + std::to_string(currPic->poc) + " borderExtTask lrB UV Ref-POC:" + std::to_string(pic->poc) )
+                                        task,
+                                        pic,
+                                        &pic->m_borderExtTaskCounter,
+                                        nullptr,
+                                        { wrapAround ? &pic->m_copyWrapBufDone : &pic->reconDone } );
   }
   {
-    static auto task = []( int, Picture* picture ) {
+    static auto task = []( int, void* task_param )
+    {
       ITT_TASKSTART( itt_domain_dec, itt_handle_ext );
+      Picture* picture = static_cast<Picture*>( task_param );
       picture->extendPicBorder( false, false, false, true, CH_C );
       ITT_TASKEND( itt_domain_dec, itt_handle_ext );
       return true;
     };
-    m_decodeThreadPool->addBarrierTask<Picture>( TP_TASK_NAME_ARG( "POC:" + std::to_string(currPic->poc) + " borderExtTask lrB UV Ref-POC:" + std::to_string(pic->poc) )
-                                                 task,
-                                                 pic,
-                                                 &pic->m_borderExtTaskCounter,
-                                                 nullptr,
-                                                 { wrapAround ? &pic->m_copyWrapBufDone : &pic->reconDone } );
+    m_decodeThreadPool->addBarrierTask( TP_TASK_NAME_ARG( "POC:" + std::to_string(currPic->poc) + " borderExtTask lrB UV Ref-POC:" + std::to_string(pic->poc) )
+                                        task,
+                                        pic,
+                                        &pic->m_borderExtTaskCounter,
+                                        nullptr,
+                                        { wrapAround ? &pic->m_copyWrapBufDone : &pic->reconDone } );
   }
 }
 
@@ -386,18 +400,20 @@ void DecLibRecon::createSubPicRefBufs( Picture* pic, const Picture* currPic )
 
     pic->m_subPicRefBufs[i].create( pic->chromaFormat, Size( subPicArea ), sps->getMaxCUWidth(), pic->margin, MEMORY_ALIGN_DEF_SIZE );
 
-    static auto task = []( int, SubPicExtTask* t ) {
+    static auto task = []( int, void* task_param )
+    {
+      SubPicExtTask* t = static_cast<SubPicExtTask*>( task_param );
       t->subPicBuf->copyFrom( t->picture->getRecoBuf().subBuf( t->subPicArea ) );
       t->picture->extendPicBorderBuf( *t->subPicBuf );
       return true;
     };
     m_subPicExtTasks.emplace_back( SubPicExtTask{ pic, &pic->m_subPicRefBufs[i], subPicArea } );
-    m_decodeThreadPool->addBarrierTask<SubPicExtTask>( TP_TASK_NAME_ARG( "POC:" + std::to_string( currPic->poc ) + " subPicBorderExtTask refPOC:" + std::to_string( pic->poc ) )
-                                                       task,
-                                                       &m_subPicExtTasks.back(),
-                                                       &pic->m_borderExtTaskCounter,
-                                                       nullptr,
-                                                       { &pic->reconDone } );
+    m_decodeThreadPool->addBarrierTask( TP_TASK_NAME_ARG( "POC:" + std::to_string( currPic->poc ) + " subPicBorderExtTask refPOC:" + std::to_string( pic->poc ) )
+                                        task,
+                                        &m_subPicExtTasks.back(),
+                                        &pic->m_borderExtTaskCounter,
+                                        nullptr,
+                                        { &pic->reconDone } );
   }
 }
 
@@ -611,20 +627,21 @@ void DecLibRecon::decompressPicture( Picture* pcPic )
         param->numColPerTask   = numColPerTask;
         param->numTasksPerLine = numTasksPerLine;
 
-        m_decodeThreadPool->addBarrierTask<CtuTaskParam>( TP_TASK_NAME_ARG( "POC:" + std::to_string(pcPic->poc) + " ctuTask:" + std::to_string( col ) + "," + std::to_string( line ) )
-                                                          ctuTask<false>,
-                                                          param,
-                                                          &pcPic->m_ctuTaskCounter,
-                                                          nullptr,
-                                                          std::move( ctuBarriesrs ),
-                                                          ctuTask<true> );
+        m_decodeThreadPool->addBarrierTask( TP_TASK_NAME_ARG( "POC:" + std::to_string(pcPic->poc) + " ctuTask:" + std::to_string( col ) + "," + std::to_string( line ) )
+                                            ctuTask<false>,
+                                            param,
+                                            &pcPic->m_ctuTaskCounter,
+                                            nullptr,
+                                            std::move( ctuBarriesrs ),
+                                            ctuTask<true> );
       }
     }
   }
 
   {
-    static auto finishReconTask = []( int, FinishPicTaskParam* param )
+    static auto finishReconTask = []( int, void* task_param )
     {
+      FinishPicTaskParam* param = static_cast<FinishPicTaskParam*>( task_param );
       CodingStructure& cs = *param->pic->cs;
 
       if( cs.sps->getUseALF() && !AdaptiveLoopFilter::getAlfSkipPic( cs ) )
@@ -645,12 +662,12 @@ void DecLibRecon::decompressPicture( Picture* pcPic )
     };
 
     taskFinishPic = FinishPicTaskParam( this, pcPic );
-    m_decodeThreadPool->addBarrierTask<FinishPicTaskParam>( TP_TASK_NAME_ARG( "POC:" + std::to_string( pcPic->poc ) + " finishPicTask" )
-                                                            finishReconTask,
-                                                            &taskFinishPic,
-                                                            &pcPic->m_divTasksCounter,
-                                                            &pcPic->reconDone,
-                                                            { pcPic->m_ctuTaskCounter.donePtr() } );
+    m_decodeThreadPool->addBarrierTask( TP_TASK_NAME_ARG( "POC:" + std::to_string( pcPic->poc ) + " finishPicTask" )
+                                        finishReconTask,
+                                        &taskFinishPic,
+                                        &pcPic->m_divTasksCounter,
+                                        &pcPic->reconDone,
+                                        { pcPic->m_ctuTaskCounter.donePtr() } );
   }
 
   if( m_decodeThreadPool->numThreads() == 0 )
@@ -705,8 +722,10 @@ void DecLibRecon::cleanupOnException( std::exception_ptr exception )
 }
 
 template<bool onlyCheckReadyState>
-bool DecLibRecon::ctuTask( int tid, CtuTaskParam* param )
+bool DecLibRecon::ctuTask( int tid, void* task_param )
 {
+  CtuTaskParam* param = static_cast<CtuTaskParam*>( task_param );
+
   const int       taskCol      = param->taskCol;
   const int       line         = param->taskLine;
   const int       col          = taskCol;

--- a/source/Lib/DecoderLib/DecLibRecon.h
+++ b/source/Lib/DecoderLib/DecLibRecon.h
@@ -196,7 +196,7 @@ private:
   void createSubPicRefBufs( Picture* pic, const Picture* currPic );
 
   template<bool checkReadyState=false>
-  static bool ctuTask( int tid, CtuTaskParam* param );
+  static bool ctuTask( int tid, void* task_param );
 };
 
 }

--- a/source/Lib/Utilities/ThreadPool.h
+++ b/source/Lib/Utilities/ThreadPool.h
@@ -416,14 +416,13 @@ public:
   ThreadPool( int numThreads = 1, const char *threadPoolName = nullptr );
   ~ThreadPool();
 
-  template<class TParam>
   bool addBarrierTask( TP_TASK_NAME_ARG( std::string&& taskName )
-                       bool       ( *func )( int, TParam* ),
-                       TParam*       param,
-                       WaitCounter*  counter                      = nullptr,
-                       Barrier*      done                         = nullptr,
-                       CBarrierVec&& barriers                     = {},
-                       bool       ( *readyCheck )( int, TParam* ) = nullptr )
+                       bool       ( *func )( int, void* ),
+                       void*         param,
+                       WaitCounter*  counter                    = nullptr,
+                       Barrier*      done                       = nullptr,
+                       CBarrierVec&& barriers                   = {},
+                       bool       ( *readyCheck )( int, void* ) = nullptr )
   {
     if( m_threads.empty() )
     {

--- a/source/Lib/vvdec/vvdecimpl.cpp
+++ b/source/Lib/vvdec/vvdecimpl.cpp
@@ -895,8 +895,9 @@ void VVDecImpl::xAddGrain( vvdecFrame* frame )
     grainTaskData[i].startLine      = i * LINES_PER_TASK;
     grainTaskData[i].filmGrainSynth = m_filmGrainSynth.get();
 
-    static auto grainTask = []( int, GrainTaskData* data )
+    static auto grainTask = []( int, void* param )
     {
+      GrainTaskData* data  = static_cast<GrainTaskData*>( param );
       auto* frame = data->frame;
       for( unsigned y = data->startLine; y < std::min( data->startLine + LINES_PER_TASK, frame->planes[0].height ); ++y )
       {
@@ -915,7 +916,7 @@ void VVDecImpl::xAddGrain( vvdecFrame* frame )
       }
       return true;
     };
-    m_cDecLib->getThreadPool().addBarrierTask<GrainTaskData>( grainTask, &( grainTaskData[i] ), &grainTaskCounter );
+    m_cDecLib->getThreadPool().addBarrierTask( grainTask, &( grainTaskData[i] ), &grainTaskCounter );
   }
   grainTaskCounter.wait();
 


### PR DESCRIPTION
analogous to fraunhoferhhi/vvenc#689

Functions called through a fuction pointer need to exactly match the type of the function pointer. So passing a typed pointer as an argument of type void* and implicitly interpreting it as the original type is undefined behavior.

The thread pool task functions now all take a void* parameter, which is then explicitly casted to the actually used struct inside the task function.