### PR TITLE
Fix PVS-Studio V564 warnings in LoopFilter

### DIFF
--- a/source/Lib/CommonLib/LoopFilter.cpp
+++ b/source/Lib/CommonLib/LoopFilter.cpp
@@ -1171,9 +1171,9 @@ void LoopFilter::xGetBoundaryStrengthSingle( LoopFilterParam& lfp, const CodingU
     tmpBs += BsSet( cbfSum & 1, COMPONENT_Y );
     if( !( MODE_INTRA != cuP.predMode() && MODE_INTRA != cuQ.predMode() && cuPcIsIntra ) )
     {
-      bool jointChr = tuQ.jointCbCr || tuP.jointCbCr;
+      int jointChr = ( tuQ.jointCbCr || tuP.jointCbCr ) ? 1 : 0;
       cbfSum >>= 1;
-      tmpBs += BsSet( (cbfSum & 1) | jointChr , COMPONENT_Cb );
+      tmpBs += BsSet( (cbfSum & 1) | jointChr, COMPONENT_Cb );
       cbfSum >>= 1;
       tmpBs += BsSet( (cbfSum & 1) | jointChr, COMPONENT_Cr );
     }


### PR DESCRIPTION
Replace bitwise OR with logical OR when combining CBF and joint Cb/Cr flags in the loop filter boundary strength calculation.

The operands are boolean-style conditions here: `(cbfSum & 1)` is either 0 or 1, and `jointChr` is already a `bool`. Using `||` keeps the same effective value passed to `BsSet` while matching the intended logical operation and addressing the PVS-Studio V564 warnings.

Refs #167

Tested:
- cmake -S . -B build/static -DCMAKE_BUILD_TYPE=Release -DBUILD_SHARED_LIBS=0
- cmake --build build/static -j 8
- ctest --test-dir build/static --output-on-failure -R unit_test