### PR TITLE
SAO: Fix vertical virtual boundary check in offsetCTU

### DIFF
--- a/source/Lib/CommonLib/SampleAdaptiveOffset.cpp
+++ b/source/Lib/CommonLib/SampleAdaptiveOffset.cpp
@@ -683,7 +683,7 @@ void SampleAdaptiveOffset::offsetCTU( const UnitArea& area, const CPelUnitBuf& s
   if( isCtuCrossedByVirtualBoundaries )
   {
     CHECK( numHorVirBndry >= (int)( sizeof(horVirBndryPos) / sizeof(horVirBndryPos[0]) ), "Too many virtual boundaries" );
-    CHECK( numHorVirBndry >= (int)( sizeof(verVirBndryPos) / sizeof(verVirBndryPos[0]) ), "Too many virtual boundaries" );
+    CHECK( numVerVirBndry >= (int)( sizeof(verVirBndryPos) / sizeof(verVirBndryPos[0]) ), "Too many virtual boundaries" );
   }
 
   for(int compIdx = 0; compIdx < numberOfComponents; compIdx++)


### PR DESCRIPTION
Use `numVerVirBndry` when validating `verVirBndryPos` so the CHECK matches the array being protected.