### PR TITLE
Add unit tests for AdaptiveLoopFilter::filterBlkCcAlfBoth

### DIFF
--- a/source/Lib/CommonLib/AdaptiveLoopFilter.h
+++ b/source/Lib/CommonLib/AdaptiveLoopFilter.h
@@ -131,7 +131,12 @@ public:
   void ( *m_filter7x7Blk )( const AlfClassifier* classifier, const PelUnitBuf& recDst, const CPelUnitBuf& recSrc,
                             const Area& blk, const ComponentID compId, const short* filterSet, const short* fClipSet,
                             const ClpRng& clpRng, int vbCTUHeight, int vbPos, const bool isFixedFilterSet );
-  void ( *m_deriveClassificationBlk )( AlfClassifier *classifier, const CPelBuf& srcLuma, const Area& blk, const int shift, int vbCTUHeight, int vbPos );
+  void ( *m_filterCcAlfBoth )( const PelBuf& dstBufCb, const PelBuf& dstBufCr, const CPelUnitBuf& recSrc,
+                               const Area& blkDst, const Area& blkSrc, const int16_t* filterCoeffCb,
+                               const int16_t* filterCoeffCr, const ClpRngs& clpRngs, int vbCTUHeight, int vbPos );
+  void ( *m_deriveClassificationBlk )( AlfClassifier* classifier, const CPelBuf& srcLuma, const Area& blk,
+                                       const int shift, int vbCTUHeight, int vbPos );
+
 protected:
 
   static void deriveClassificationBlk( AlfClassifier *classifier, const CPelBuf& srcLuma, const Area& blk, const int shift, int vbCTUHeight, int vbPos );
@@ -145,9 +150,6 @@ protected:
   template<AlfFilterType filtType>
   static void filterBlk              ( const AlfClassifier *classifier, const PelUnitBuf &recDst, const CPelUnitBuf& recSrc, const Area& blk, const ComponentID compId, const short* filterSet, const short* fClipSet, const ClpRng& clpRng, int vbCTUHeight, int vbPos, const bool isFixedFilterSet );
   void ( *m_filterCcAlf )            ( const PelBuf &dstBuf, const CPelUnitBuf &recSrc, const Area &blkDst, const Area &blkSrc, const ComponentID compId, const int16_t *filterCoeff, const ClpRngs &clpRngs, int vbCTUHeight, int vbPos );
-  void ( *m_filterCcAlfBoth )        ( const PelBuf& dstBufCb, const PelBuf& dstBufCr, const CPelUnitBuf &recSrc, const Area &blkDst,
-                                      const Area &blkSrc, const int16_t* filterCoeffCb, const int16_t* filterCoeffCr,
-                                      const ClpRngs &clpRngs, int vbCTUHeight, int vbPos );
 
 #if defined(TARGET_SIMD_X86)  && ENABLE_SIMD_OPT_ALF
   void initAdaptiveLoopFilterX86();

--- a/tests/vvdec_unit_test/vvdec_unit_test.cpp
+++ b/tests/vvdec_unit_test/vvdec_unit_test.cpp
@@ -549,6 +549,143 @@ static bool check_filterBlk( AdaptiveLoopFilter* ref, AdaptiveLoopFilter* opt, u
   return true;
 }
 
+static int16_t getRandomCcAlfCoeff( DimensionGenerator& rng )
+{
+  // CC-ALF coeffs are signalled as zero or signed powers of two from mapped 3-bit abs levels.
+  static constexpr int16_t ccAlfCoeffLevels[] = { 0, 1, -1, 2, -2, 4, -4, 8, -8, 16, -16, 32, -32, 64, -64 };
+  return ccAlfCoeffLevels[rng.get( 0, sizeof( ccAlfCoeffLevels ) / sizeof( ccAlfCoeffLevels[0] ) - 1 )];
+}
+
+static bool check_one_filterBlkCcAlfBoth( AdaptiveLoopFilter* ref, AdaptiveLoopFilter* opt, ChromaFormat chromaFormat,
+                                          unsigned chromaW, unsigned chromaH, std::ostringstream& sstm_test )
+{
+  CHECK( chromaW % 4, "filterBlkCcAlfBoth width must be a multiple of 4" );
+  CHECK( chromaH % 4, "filterBlkCcAlfBoth height must be a multiple of 4" );
+
+  static constexpr unsigned bd = 10; // Test 10-bit only as bit depth only changes the ClipPel range and offset.
+  const ClpRngs clpRng{ ( int )bd };
+  DimensionGenerator rng;
+  InputGenerator<Pel> gen{ bd, /*is_signed=*/false };
+
+  // filterAreaChromaBothCc passes zero-origin areas, so clear all block offsets.
+  static constexpr unsigned chromaX = 0;
+  static constexpr unsigned chromaY = 0;
+  static constexpr unsigned lumaX = 0;
+  static constexpr unsigned lumaY = 0;
+
+  const int scaleX = getComponentScaleX( COMPONENT_Cb, chromaFormat );
+  const int scaleY = getComponentScaleY( COMPONENT_Cb, chromaFormat );
+  const unsigned lumaW = chromaW << scaleX;
+  const unsigned lumaH = chromaH << scaleY;
+
+  // Add luma padding so the seven CC-ALF neighbor samples stay in bounds.
+  // The filter reads one sample left/right, one row above, and two rows below.
+  static constexpr unsigned padL = 1;
+  static constexpr unsigned padR = 16; // Allow extra right-side samples for SIMD vector loads.
+  static constexpr unsigned padT = 1;
+  static constexpr unsigned padB = 2;
+  static constexpr unsigned lumaPadX = padL + padR;
+  static constexpr unsigned lumaPadY = padT + padB;
+
+  const unsigned lumaRows = lumaH + lumaY;
+  const unsigned lumaCols = lumaW + lumaX;
+  const unsigned lumaPaddedRows = lumaRows + lumaPadY;
+  const unsigned lumaPaddedCols = lumaCols + lumaPadX;
+  const unsigned lumaMaxPaddedCols = MAX_CU_SIZE + lumaX + lumaPadX;
+
+  const unsigned chromaRows = chromaH + chromaY;
+  const unsigned chromaCols = chromaW + chromaX;
+  const unsigned chromaMaxCols = MAX_CU_SIZE + chromaX;
+
+  // Strides must also cover the block offset (and luma padding) so blkDst/blkSrc stay in bounds.
+  const ptrdiff_t lumaStride = rng.get( lumaPaddedCols, lumaMaxPaddedCols );
+  const ptrdiff_t chromaStride = rng.get( chromaCols, chromaMaxCols );
+
+  std::ostringstream sstm_subtest;
+  sstm_subtest << sstm_test.str() << " lumaStride=" << lumaStride << " chromaStride=" << chromaStride
+               << " chromaW=" << chromaW << " chromaH=" << chromaH;
+
+  std::vector<Pel> luma( lumaPaddedRows * lumaStride ); // Create luma buffer with padding.
+  std::vector<Pel> cbRef( chromaRows * chromaStride );
+  std::vector<Pel> crRef( chromaRows * chromaStride );
+
+  std::generate( luma.begin(), luma.end(), gen );
+  std::generate( cbRef.begin(), cbRef.end(), gen );
+  std::generate( crRef.begin(), crRef.end(), gen );
+
+  std::vector<Pel> cbOpt = cbRef;
+  std::vector<Pel> crOpt = crRef;
+
+  // Buffer sizes describe the full plane (origin to the end of the filtered block).
+  Size lumaSize{ lumaCols, lumaRows };
+  Size chromaSize{ chromaCols, chromaRows };
+
+  // filterBlkCcAlfBoth only uses chromaFormat and srcY from srcUnitBuf.
+  // srcCb/srcCr planes are only used to form CPelUnitBuf.
+  AreaBuf<const Pel> srcY{ luma.data() + padT * lumaStride + padL, lumaStride, lumaSize };
+  AreaBuf<const Pel> srcCb{ cbRef.data(), chromaStride, chromaSize };
+  AreaBuf<const Pel> srcCr{ crRef.data(), chromaStride, chromaSize };
+  CPelUnitBuf srcUnitBuf{ chromaFormat, srcY, srcCb, srcCr };
+
+  PelBuf dstCbRef{ cbRef.data(), chromaStride, chromaSize };
+  PelBuf dstCrRef{ crRef.data(), chromaStride, chromaSize };
+  PelBuf dstCbOpt{ cbOpt.data(), chromaStride, chromaSize };
+  PelBuf dstCrOpt{ crOpt.data(), chromaStride, chromaSize };
+
+  int16_t coeffCb[MAX_NUM_CC_ALF_CHROMA_COEFF] = { 0 };
+  int16_t coeffCr[MAX_NUM_CC_ALF_CHROMA_COEFF] = { 0 };
+  for( unsigned i = 0; i < MAX_NUM_CC_ALF_CHROMA_COEFF - 1; ++i )
+  {
+    coeffCb[i] = getRandomCcAlfCoeff( rng );
+    coeffCr[i] = getRandomCcAlfCoeff( rng );
+  }
+
+  const Area blkDst{ ( int )chromaX, ( int )chromaY, chromaW, chromaH };
+  const Area blkSrc{ ( int )lumaX, ( int )lumaY, lumaW, lumaH };
+
+  const int sps_log2_ctu_size_minus5 = rng.get( 0, 2 );          // From sps->setCTUSize().
+  const int vbCTUHeight = 1 << ( sps_log2_ctu_size_minus5 + 5 ); // { 32, 64, 128 }
+  const int vbPos = vbCTUHeight - ALF_VB_POS_ABOVE_CTUROW_LUMA;  // { 28, 60, 124 }
+
+  ref->m_filterCcAlfBoth( dstCbRef, dstCrRef, srcUnitBuf, blkDst, blkSrc, coeffCb, coeffCr, clpRng, vbCTUHeight,
+                          vbPos );
+  opt->m_filterCcAlfBoth( dstCbOpt, dstCrOpt, srcUnitBuf, blkDst, blkSrc, coeffCb, coeffCr, clpRng, vbCTUHeight,
+                          vbPos );
+
+  bool passed = true;
+  passed = compare_values_2d( sstm_subtest.str() + " Cb optimized", cbRef.data(), cbOpt.data(), chromaRows,
+                              ( unsigned )chromaStride ) &&
+           passed;
+  passed = compare_values_2d( sstm_subtest.str() + " Cr optimized", crRef.data(), crOpt.data(), chromaRows,
+                              ( unsigned )chromaStride ) &&
+           passed;
+
+  return passed;
+}
+
+static bool check_filterBlkCcAlfBoth( AdaptiveLoopFilter* ref, AdaptiveLoopFilter* opt, unsigned num_cases,
+                                      ChromaFormat chromaFormat, unsigned w, unsigned h )
+{
+  static constexpr const char* chromaFormatNames[NUM_CHROMA_FORMAT] =
+  {
+    "CHROMA_400", "CHROMA_420", "CHROMA_422", "CHROMA_444"
+  };
+
+  std::ostringstream sstm_test;
+  sstm_test << "AdaptiveLoopFilter::filterBlkCcAlfBoth format=" << chromaFormatNames[chromaFormat] << " w=" << w
+            << " h=" << h;
+  std::cout << "Testing " << sstm_test.str() << std::endl;
+
+  bool passed = true;
+
+  for( unsigned i = 0; i < num_cases; ++i )
+  {
+    passed = check_one_filterBlkCcAlfBoth( ref, opt, chromaFormat, w, h, sstm_test ) && passed;
+  }
+
+  return passed;
+}
+
 static bool test_AdaptiveLoopFilter()
 {
   AdaptiveLoopFilter ref{ /*enableOpt=*/false };
@@ -578,6 +715,18 @@ static bool test_AdaptiveLoopFilter()
     for( unsigned h : { 4, 8, 16, 24, 32, 40, 48, 56, 64 } )
     {
       passed = check_filterBlk<ALF_FILTER_5>( &ref, &opt, num_cases, w, h ) && passed;
+    }
+  }
+
+  // CHROMA_400 does not use the CC-ALF filter.
+  for( ChromaFormat chromaFormat : { CHROMA_420, CHROMA_422, CHROMA_444 } )
+  {
+    for( unsigned w : { 4, 8, 12, 16, 20, 32, 64 } )
+    {
+      for( unsigned h : { 4, 8, 16, 24, 32 } )
+      {
+        passed = check_filterBlkCcAlfBoth( &ref, &opt, num_cases, chromaFormat, w, h ) && passed;
+      }
     }
   }
 


### PR DESCRIPTION
Add unit tests for `AdaptiveLoopFilter::filterBlkCcAlfBoth` by comparing the scalar and SIMD implementations across chroma types.

Move the `m_filterCcAlfBoth` function pointer from protected to public so the unit test can invoke the selected scalar or SIMD implementation directly.