### PR TITLE
fix potential security issue

### DIFF
--- a/source/Lib/vvdec/vvdecimpl.cpp
+++ b/source/Lib/vvdec/vvdecimpl.cpp
@@ -395,7 +395,7 @@ int VVDecImpl::decode( vvdecAccessUnit& rcAccessUnit, vvdecFrame** ppcFrame )
         rBitstream.clearEmulationPreventionByteLocation();
 
         size_t numNaluBytes = iAUEndPosVec[iAU] - iStartCodePosVec[iAU];
-        if( numNaluBytes )
+        if( numNaluBytes >= 2 )
         {
           const uint8_t*    naluData = &rcAccessUnit.payload[iStartCodePosVec[iAU]];
           const NalUnitType nut      = (NalUnitType) ( ( naluData[1] >> 3 ) & 0x1f );


### PR DESCRIPTION
- an off-by-one boundary check in VVDecImpl::decode() at vvdecimpl.cpp:401 allows a 1-byte heap out-of-bounds read when processing a crafted VVC bitstream with a 1-byte NALU.
- check was `if(numNaluBytes)` only checks for non-zero length, but naluData[1] requires at least 2 bytes
- when attacker crafts a VVC bitstream with a 1-byte NALU, numNaluBytes==1 passes the check, and naluData[1] reads 1 byte past the allocated heap buffer.