### PR TITLE
CTest: Remove 120s vvdec_unit_test timeout

### DIFF
--- a/tests/vvdec_unit_test/CMakeLists.txt
+++ b/tests/vvdec_unit_test/CMakeLists.txt
@@ -49,4 +49,3 @@ source_group( "Resource Files" FILES ${RESOURCE_FILE} )
 set_target_properties( ${EXE_NAME} PROPERTIES FOLDER tests )
 
 add_test( NAME vvdec_unit_test COMMAND ${VVDEC_TESTS_DEBUGGER_COMMAND} $<TARGET_FILE:${EXE_NAME}> )
-set_tests_properties( vvdec_unit_test PROPERTIES TIMEOUT 120 )


### PR DESCRIPTION
The `vvdec_unit_test` has grown with additional SIMD coverage, and the hard-coded 120s CTest timeout can expire on slower CI runners while the test is still in progress.