### PR TITLE
Arm: Fix Windows SVE compilation with Clang and MSYS2

### DIFF
--- a/cmake/modules/vvdecCompilerSupport.cmake
+++ b/cmake/modules/vvdecCompilerSupport.cmake
@@ -124,11 +124,7 @@ endfunction()
 # Check if the compiler supports the AArch64 RDM, SVE, and SVE2 extensions, and set
 # variables for flags used to enable them to avoid duplication.
 function( set_if_compiler_supports_arm_extensions output_flag_rdm output_flag_sve output_flag_sve2 )
-  if( NOT(( ${CMAKE_SYSTEM_PROCESSOR} MATCHES "arm64" ) OR
-          ( ${CMAKE_SYSTEM_PROCESSOR} MATCHES "aarch64" )))
-    return()
-  endif()
-  if( UNIX OR MINGW )
+  if( NOT MSVC )
     # Neon RDM is mandatory from Armv8.1-A.
     set( _flag_rdm "-march=armv8.1-a" )
     set_if_compiler_supports_flag( _rdm_supported "${_flag_rdm}" )


### PR DESCRIPTION
The existing Windows build with Clang and MSYS2 on AArch64 currently fails to pick up the SVE/SVE2 flags since the environment does not satisfy `UNIX OR MINGW`. Adjust this to just be `NOT MSVC`.

Delete the `CMAKE_SYSTEM_PROCESSOR` guard since this function is only called when `VVDEC_TARGET_ARCH` already matches.