### PR TITLE
Arm: Add Neon implementation for Picture border padding

### DIFF
--- a/source/Lib/CommonLib/Picture.cpp
+++ b/source/Lib/CommonLib/Picture.cpp
@@ -235,6 +235,9 @@ Picture::Picture( bool enableOpt )
 #if ENABLE_SIMD_OPT_PICTURE && defined( TARGET_SIMD_X86 )
     initPictureX86();
 #endif
+#if ENABLE_SIMD_OPT_PICTURE && defined( TARGET_SIMD_ARM )
+    initPictureARM();
+#endif
   }
 }
 

--- a/source/Lib/CommonLib/Picture.h
+++ b/source/Lib/CommonLib/Picture.h
@@ -63,6 +63,9 @@ namespace vvdec
 #if  ENABLE_SIMD_OPT_PICTURE && defined( TARGET_SIMD_X86 )
 using namespace x86_simd;
 #endif
+#if ENABLE_SIMD_OPT_PICTURE && defined( TARGET_SIMD_ARM )
+using namespace arm_simd;
+#endif
 
 struct Picture;
 
@@ -286,6 +289,12 @@ public:
   void initPictureX86();
   template <X86_VEXT vext>
   void _initPictureX86();
+#endif
+
+#if ENABLE_SIMD_OPT_PICTURE && defined( TARGET_SIMD_ARM )
+  void initPictureARM();
+  template <ARM_VEXT vext>
+  void _initPictureARM();
 #endif
 };
 

--- a/source/Lib/CommonLib/arm/InitARM.cpp
+++ b/source/Lib/CommonLib/arm/InitARM.cpp
@@ -197,15 +197,16 @@ void InterPrediction::initInterPredictionARM()
 }
 #endif
 
-//#  if ENABLE_SIMD_OPT_PICTURE
-//void Picture::initPictureARM()
-//{
-//  auto vext = read_arm_extension_flags();
-//  if( vext >= NEON )
-//  {
-//    _initPictureARM<NEON>();
-//  }
-//#  endif
+#if ENABLE_SIMD_OPT_PICTURE
+void Picture::initPictureARM()
+{
+  auto vext = read_arm_extension_flags();
+  if( vext >= NEON )
+  {
+    _initPictureARM<NEON>();
+  }
+}
+#endif
 
 //#  if ENABLE_SIMD_OPT_QUANT
 //void Quant::initQuantARM()

--- a/source/Lib/CommonLib/arm/neon/Picture_neon.cpp
+++ b/source/Lib/CommonLib/arm/neon/Picture_neon.cpp
@@ -1,0 +1,168 @@
+/* -----------------------------------------------------------------------------
+The copyright in this software is being made available under the Clear BSD
+License, included below. No patent rights, trademark rights and/or
+other Intellectual Property Rights other than the copyrights concerning
+the Software are granted under this license.
+
+The Clear BSD License
+
+Copyright (c) 2018-2026, Fraunhofer-Gesellschaft zur Förderung der angewandten Forschung e.V. & The VVdeC Authors.
+All rights reserved.
+
+Redistribution and use in source and binary forms, with or without modification,
+are permitted (subject to the limitations in the disclaimer below) provided that
+the following conditions are met:
+
+     * Redistributions of source code must retain the above copyright notice,
+     this list of conditions and the following disclaimer.
+
+     * Redistributions in binary form must reproduce the above copyright
+     notice, this list of conditions and the following disclaimer in the
+     documentation and/or other materials provided with the distribution.
+
+     * Neither the name of the copyright holder nor the names of its
+     contributors may be used to endorse or promote products derived from this
+     software without specific prior written permission.
+
+NO EXPRESS OR IMPLIED LICENSES TO ANY PARTY'S PATENT RIGHTS ARE GRANTED BY
+THIS LICENSE. THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND
+CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A
+PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR
+CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR
+BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER
+IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+POSSIBILITY OF SUCH DAMAGE.
+
+
+-------------------------------------------------------------------------------------------
+*/
+
+/**
+ * \file Picture_neon.cpp
+ * \brief Neon picture border padding.
+ */
+
+#include "CommonLib/arm/CommonDefARM.h"
+#include "CommonLib/CommonDef.h"
+#include "CommonLib/Picture.h"
+
+//! \ingroup CommonLib
+//! \{
+
+#if defined( TARGET_SIMD_ARM ) && ENABLE_SIMD_OPT_PICTURE
+
+namespace vvdec
+{
+
+static void paddPicBorderLeftRight_neon( Pel* pi, ptrdiff_t stride, int width, int xmargin, int height )
+{
+  for( int i = 1; i < height - 1; i++ )
+  {
+    const int16x8_t xleft  = vdupq_n_s16( pi[0] );
+    const int16x8_t xright = vdupq_n_s16( pi[width - 1] );
+
+    int temp = xmargin;
+    int x    = 0;
+    while( ( temp >> 3 ) > 0 )
+    {
+      vst1q_s16( pi - xmargin + x, xleft );
+      vst1q_s16( pi + width   + x, xright );
+      x    += 8;
+      temp -= 8;
+    }
+    while( ( temp >> 2 ) > 0 )
+    {
+      vst1_s16( pi - xmargin + x, vget_low_s16( xleft ) );
+      vst1_s16( pi + width   + x, vget_low_s16( xright ) );
+      x    += 4;
+      temp -= 4;
+    }
+    while( ( temp >> 1 ) > 0 )
+    {
+      *( int32_t* )( pi - xmargin + x ) = vgetq_lane_s32( vreinterpretq_s32_s16( xleft ),  0 );
+      *( int32_t* )( pi + width   + x ) = vgetq_lane_s32( vreinterpretq_s32_s16( xright ), 0 );
+      x    += 2;
+      temp -= 2;
+    }
+    pi += stride;
+  }
+}
+
+static void paddPicBorderBot_neon( Pel* pi, ptrdiff_t stride, int width, int xmargin, int ymargin )
+{
+  paddPicBorderLeftRight_neon( pi, stride, width, xmargin, 3 );
+
+  pi -= xmargin;
+
+  for( int i = 1; i <= ymargin; i++ )
+  {
+    int j    = 0;
+    int temp = width + ( xmargin << 1 );
+    while( ( temp >> 3 ) > 0 )
+    {
+      vst1q_s16( pi + j + i * stride, vld1q_s16( pi + j ) );
+      j    += 8;
+      temp -= 8;
+    }
+    while( ( temp >> 2 ) > 0 )
+    {
+      vst1_s16( pi + j + i * stride, vld1_s16( pi + j ) );
+      j    += 4;
+      temp -= 4;
+    }
+    while( ( temp >> 1 ) > 0 )
+    {
+      *( int32_t* )( pi + j + i * stride ) = *( const int32_t* )( pi + j );
+      j    += 2;
+      temp -= 2;
+    }
+  }
+}
+
+static void paddPicBorderTop_neon( Pel* pi, ptrdiff_t stride, int width, int xmargin, int ymargin )
+{
+  paddPicBorderLeftRight_neon( pi, stride, width, xmargin, 3 );
+
+  pi -= xmargin;
+
+  for( int i = 1; i <= ymargin; i++ )
+  {
+    int j    = 0;
+    int temp = width + ( xmargin << 1 );
+    while( ( temp >> 3 ) > 0 )
+    {
+      vst1q_s16( pi + j - i * stride, vld1q_s16( pi + j ) );
+      j    += 8;
+      temp -= 8;
+    }
+    while( ( temp >> 2 ) > 0 )
+    {
+      vst1_s16( pi + j - i * stride, vld1_s16( pi + j ) );
+      j    += 4;
+      temp -= 4;
+    }
+    while( ( temp >> 1 ) > 0 )
+    {
+      *( int32_t* )( pi + j - i * stride ) = *( const int32_t* )( pi + j );
+      j    += 2;
+      temp -= 2;
+    }
+  }
+}
+
+template<>
+void Picture::_initPictureARM<NEON>()
+{
+  paddPicBorderBot       = paddPicBorderBot_neon;
+  paddPicBorderTop       = paddPicBorderTop_neon;
+  paddPicBorderLeftRight = paddPicBorderLeftRight_neon;
+}
+
+} // namespace vvdec
+
+#endif // defined( TARGET_SIMD_ARM ) && ENABLE_SIMD_OPT_PICTURE
+//! \}


### PR DESCRIPTION
Replace the scalar \`paddPicBorder{Bot,Top,LeftRight}\` routines with Neon-vectorised equivalents on AArch64.

## Changes

### \`source/Lib/CommonLib/arm/neon/Picture_neon.cpp\` (new file)
Three static helpers, each using a cascaded 128-bit → 64-bit → 32-bit store loop:
- \`paddPicBorderLeftRight_neon\` – fills left and right margins per row with \`vst1q_s16\` (8 pels), \`vst1_s16\` (4 pels), and a 32-bit store (2 pels).
- \`paddPicBorderBot_neon\` – delegates to \`paddPicBorderLeftRight_neon\` for the last two interior rows, then copies the padded bottom row downward \`ymargin\` times with the same store cascade.
- \`paddPicBorderTop_neon\` – mirrors \`paddPicBorderBot_neon\` for the top margin.

The template specialisation \`Picture::_initPictureARM<NEON>()\` wires these three helpers into the function-pointer table.

### \`source/Lib/CommonLib/arm/InitARM.cpp\`
\`Picture::initPictureARM()\` was already stubbed out but left commented. Uncommented and activated: detects \`NEON\` capability at runtime and calls \`_initPictureARM<NEON>()\`.

### \`source/Lib/CommonLib/Picture.cpp\` / \`Picture.h\`
Added \`TARGET_SIMD_ARM\` guards (mirroring the existing \`TARGET_SIMD_X86\` blocks) to call \`initPictureARM()\` from \`Picture::Picture(bool enableOpt)\` and to declare the ARM init methods.

## Testing
Built with \`-DVVDEC_ENABLE_ARM_SIMD=ON\` and validated on an AArch64 host (Oracle A1, Neoverse N1). Decoded output is bit-identical to the scalar path across a range of VVC bitstreams. Unit tests (\`paddPicBorderBottom\`, \`paddPicBorderTop\`, \`paddPicBorderLeftRight\`) all pass.