### PR TITLE
cmake: disable LTO for the Arm SIMD object library

### DIFF
--- a/source/Lib/vvdec/CMakeLists.txt
+++ b/source/Lib/vvdec/CMakeLists.txt
@@ -171,12 +171,12 @@ if( VVDEC_ENABLE_ARM_SIMD )
 
   add_library( ${LIB_NAME}_arm_simd OBJECT ${ARM_SIMD_SRC_FILES} )
 
-  # NEON is enabled by default for all files, so don't need to disable LTO
-  # set_target_properties( ${LIB_NAME}_arm_simd PROPERTIES
-  #                                             INTERPROCEDURAL_OPTIMIZATION                OFF
-  #                                             INTERPROCEDURAL_OPTIMIZATION_RELEASE        OFF
-  #                                             INTERPROCEDURAL_OPTIMIZATION_RELWITHDEBINFO OFF
-  #                                             INTERPROCEDURAL_OPTIMIZATION_MINSIZEREL     OFF )
+  # disble LTO for the files compiled with special architecture flags
+  set_target_properties( ${LIB_NAME}_arm_simd PROPERTIES
+                                              INTERPROCEDURAL_OPTIMIZATION                OFF
+                                              INTERPROCEDURAL_OPTIMIZATION_RELEASE        OFF
+                                              INTERPROCEDURAL_OPTIMIZATION_RELWITHDEBINFO OFF
+                                              INTERPROCEDURAL_OPTIMIZATION_MINSIZEREL     OFF )
 
   set_target_properties( ${LIB_NAME}_arm_simd PROPERTIES FOLDER lib )
 endif()


### PR DESCRIPTION
Since 3.2.0 the Arm SIMD object library also contains sources built with per-source architecture flags (Neon RDM, SVE and SVE2), so the assumption that all of its files only need baseline Neon no longer holds.

Building those files with LTO enabled makes GCC on AArch64 fail:

  arm_neon.h:7261:1: error: inlining failed in call to 'always_inline'
    'vqrdmlahq_s16(int16x8_t, int16x8_t, int16x8_t)':
    target specific option mismatch
  Buffer_neon_rdm.cpp:110:40: note: called from here

Apply the same treatment the x86 SIMD object library already gets and disable interprocedural optimization for the target. LTO stays enabled for every other target, and decoder output is unchanged.