### PR TITLE
Fix null pointer dereference in TMVP for undecoded reference pictures

### DIFF
--- a/source/Lib/DecoderLib/DecLibParser.cpp
+++ b/source/Lib/DecoderLib/DecLibParser.cpp
@@ -1064,6 +1064,7 @@ void DecLibParser::xActivateParameterSets( const int layerId )
     m_pcParsePic->poc          = m_apcSlicePilot->getPOC();
     m_pcParsePic->eNalUnitType = m_apcSlicePilot->getNalUnitType();
     m_pcParsePic->finalInit( &m_cuChunkCache, &m_tuChunkCache, sps, pps, m_picHeader, alfApss, lmcsAPS, scalingListAPS );
+    m_pcParsePic->cs->initStructData();
 
 #if !DISABLE_CONFROMANCE_CHECK
     m_apcSlicePilot->checkLeadingPictureRestrictions( m_dpbReferencePics );

--- a/source/Lib/DecoderLib/DecSlice.cpp
+++ b/source/Lib/DecoderLib/DecSlice.cpp
@@ -81,7 +81,6 @@ void DecSlice::parseSlice( Slice* slice, InputBitstream* bitstream, int threadId
   CodingStructure& cs = *pic->cs;
   cs.chromaQpAdj      = 0;
 
-  const int       startCtuTsAddr              = slice->getFirstCtuRsAddrInSlice();
   const unsigned  widthInCtus                 = cs.pcv->widthInCtus;
   const bool      wavefrontsEnabled           = cs.sps->getEntropyCodingSyncEnabledFlag();
   const bool      entryPointPresent           = cs.sps->getEntryPointsPresentFlag();
@@ -91,12 +90,6 @@ void DecSlice::parseSlice( Slice* slice, InputBitstream* bitstream, int threadId
   CABACReader cabacReader;
   cabacReader.initBitstream( ppcSubstreams[0].get() );
   cabacReader.initCtxModels( *slice );
-
-  // if first slice, finish init of the coding structure
-  if( startCtuTsAddr == 0 )
-  {
-    cs.initStructData();
-  }
 
   // Quantization parameter
   int prevQP[2] = { slice->getSliceQp(), slice->getSliceQp() };


### PR DESCRIPTION
Decoding the bitstream attached to #381 segfaults in the temporal MVP derivation:

    ColocatedMotionInfo::interDir()   MotionInfo.h:165
    ColocatedMotionInfo::isInter()    MotionInfo.h:172
    PU::getColocatedMVP()             UnitTools.cpp:1440
    PU::getInterMergeCandidates()     UnitTools.cpp:1116
    DecCu::xDeriveCUMV()              DecCu.cpp:788
    DecCu::TaskDeriveCtuMotionInfo()  DecCu.cpp:96

The reference to the colocated motion info is at address 0, and the read of
coRefIdx[0] faults at 0x10.

Root cause

CodingStructure::initStructData() is what wires CtuData::colMotion to m_colMiMap
and resets the map to CO_NOT_VALID. For a normally parsed picture it is only
called from DecSlice::parseSlice, guarded by startCtuTsAddr == 0, that is when
the first slice of the picture is actually decoded. Picture::progress is set to
Picture::parsing much earlier, when the slice header activates the picture
buffer.

In the attached bitstream the reference picture signalling is corrupted, several
pictures are inserted through prepareUnavailablePicture, and the slice data of
POC 19 then fails with "Exceeded FIFO size". At that point the picture has
progress == parsing but its coding structure has never been initialized.
DecLib::sanitizeBrokenPicture only calls ensureUsableAsRef(), and with it
initStructData(), when progress < Picture::parsing, so the repair is skipped.
fillGrey() replaces the samples and marks the picture reconstructed, and it stays
in the DPB as a short term reference. POC 23 then picks it as its colocated
picture and dereferences CtuData::colMotion, which is null.

Fix

Call cs->initStructData() right after Picture::finalInit() in
DecLibParser::xActivateParameterSets, which is the same pairing that
prepareUnavailablePicture already uses for generated pictures, and drop the
deferred call from DecSlice::parseSlice. Every picture in the DPB then has valid
colocated motion info before any slice data is parsed, and a broken picture
presents CO_NOT_VALID entries, so getColocatedMVP and getInterMergeSubPuMvpCand
take their existing "no colocated motion" paths. This is a move of the existing
call, not an extra one, so there is no additional per picture initialization
cost. The only behavioural difference is that the coding structure is now valid
even if slice 0's parsing fails partway through, which is what #381 exercises.

Verification

Verified locally with the file from the issue
(1920x1080_1s_25fps_yuv420p.266_mutated.bit, md5 a189e20a04b05c2d2e44e0d169e974a5).
Before the change vvdecapp segfaults with -t 0, 1, 2 and 4. After it, no crash at
any thread count, and the stream ends through the normal recoverable error path.
An address and undefined behaviour sanitizer build reports no memory error on the
same input.

Two well formed streams (low delay and random access, encoded with vvenc) decode
bit exact against the unpatched binary at -t 1 and -t 4, including a multi-tile
stream.

This needs a crafted bitstream to trigger, so it is not something the kernel
level unit tests can cover. The 6650 byte reproducer is attached to the issue if
you want it in a regression corpus.

Fixes #381