### PR TITLE
Fix null pointer dereference in Picture::fillGrey SPS check

### DIFF
--- a/source/Lib/CommonLib/Picture.cpp
+++ b/source/Lib/CommonLib/Picture.cpp
@@ -383,7 +383,7 @@ void Picture::ensureUsableAsRef()
 
 void Picture::fillGrey( const SPS* fallbackSPS )
 {
-  CHECK( !cs && !cs->sps && !fallbackSPS, "No SPS accessible" );
+  CHECK( ( !cs || !cs->sps ) && !fallbackSPS, "No SPS accessible" );
 
   const int bitDepth = cs && cs->sps ? cs->sps->getBitDepth() : fallbackSPS->getBitDepth();
   // fill in grey buffer for missing reference pictures (GDR or broken bitstream)


### PR DESCRIPTION
Picture::fillGrey dereferences cs in its SPS availability check when cs is null, because the original && expression continues evaluating after !cs is true.

    CHECK( !cs && !cs->sps && !fallbackSPS, "No SPS accessible" );

Use the correct negation so the check fails only when neither cs->sps nor fallbackSPS is available.

    CHECK( ( !cs || !cs->sps ) && !fallbackSPS, "No SPS accessible" );

Found with cppcheck.