### PR TITLE
Fix off-by-one in ReferencePictureList index bounds checks

### DIFF
--- a/source/Lib/CommonLib/Slice.cpp
+++ b/source/Lib/CommonLib/Slice.cpp
@@ -1639,7 +1639,7 @@ void ReferencePictureList::clear()
 
 void ReferencePictureList::setRefPicIdentifier( int idx, int identifier, bool isLongterm, bool isInterLayerRefPic, int interLayerIdx )
 {
-  CHECK( idx > MAX_NUM_REF_PICS, "RPL setRefPicIdentifier out of range (0-15)" );
+  CHECK( idx >= MAX_NUM_REF_PICS, "RPL setRefPicIdentifier out of range (0-15)" );
   m_refPicIdentifier[idx] = identifier;
   m_isLongtermRefPic[idx] = isLongterm;
 
@@ -1663,7 +1663,7 @@ bool ReferencePictureList::isRefPicLongterm(int idx) const
 
 void ReferencePictureList::setRefPicLongterm(int idx,bool isLongterm)
 {
-  CHECK( idx > MAX_NUM_REF_PICS, "RPL setRefPicLongterm out of range (0-15)" );
+  CHECK( idx >= MAX_NUM_REF_PICS, "RPL setRefPicLongterm out of range (0-15)" );
   m_isLongtermRefPic[idx] = isLongterm;
 }
 
@@ -1689,7 +1689,7 @@ int ReferencePictureList::getNumberOfLongtermPictures() const
 
 void ReferencePictureList::setPOC(int idx, int POC)
 {
-  CHECK( idx > MAX_NUM_REF_PICS, "RPL setPOC out of range (0-15)" );
+  CHECK( idx >= MAX_NUM_REF_PICS, "RPL setPOC out of range (0-15)" );
   m_POC[idx] = POC;
 }
 
@@ -1700,19 +1700,19 @@ int ReferencePictureList::getPOC(int idx) const
 
 void ReferencePictureList::setDeltaPocMSBCycleLT(int idx, int x)
 {
-  CHECK( idx > MAX_NUM_REF_PICS, "RPL setDeltaPocMSBCycleLT out of range (0-15)" );
+  CHECK( idx >= MAX_NUM_REF_PICS, "RPL setDeltaPocMSBCycleLT out of range (0-15)" );
   m_deltaPOCMSBCycleLT[idx] = x;
 }
 
 void ReferencePictureList::setDeltaPocMSBPresentFlag(int idx, bool x)
 {
-  CHECK( idx > MAX_NUM_REF_PICS, "RPL setDeltaPocMSBPresentFlag out of range (0-15)" );
+  CHECK( idx >= MAX_NUM_REF_PICS, "RPL setDeltaPocMSBPresentFlag out of range (0-15)" );
   m_deltaPocMSBPresentFlag[idx] = x;
 }
 
 void ReferencePictureList::setInterLayerRefPicIdx( int idx, int layerIdc )
 {
-  CHECK( idx > MAX_NUM_REF_PICS, "RPL setInterLayerRefPicIdx out of range (0-15)" );
+  CHECK( idx >= MAX_NUM_REF_PICS, "RPL setInterLayerRefPicIdx out of range (0-15)" );
   m_interLayerRefPicIdx[idx] = layerIdc;
 }
 


### PR DESCRIPTION
Six ReferencePictureList setters guard their array writes with

    CHECK( idx > MAX_NUM_REF_PICS, "RPL ... out of range (0-15)" );

MAX_NUM_REF_PICS is 16 and all the arrays written by these setters are declared with that size, so valid indices are 0 to 15, as the message says. The condition only rejects idx > 16, so idx == 16 passes and writes one element past the end.

Use >= so the upper-bound check rejects 16 and matches the arrays' exclusive upper bound.

Affected setters in Slice.cpp: setRefPicIdentifier, setRefPicLongterm, setPOC, setDeltaPocMSBCycleLT, setDeltaPocMSBPresentFlag, setInterLayerRefPicIdx.

No current caller can reach idx == 16. setRefPicIdentifier is called from parseRefPicList, where the loop bound num_ref_entries is range checked to at most MAX_NUM_REF_PICS by X_READ_UVLC_idx, and from the LTRP loop in the header parser, bounded by getNumRefEntries(), whose component counts are populated from that same parseRefPicList count in the current code. setDeltaPocMSBPresentFlag and setDeltaPocMSBCycleLT are called only from that LTRP loop. setRefPicLongterm, setPOC and setInterLayerRefPicIdx currently have no callers at all. So this does not fix a currently reachable bug, it corrects the setters' upper-bound checks, using the same >= form as other array-index checks in Slice.h and Slice.cpp (for example CHECK( i >= MAX_NUM_SUB_PICS, ... )).

Found with cppcheck.