### PR TITLE
Do not let exceptions escape PelStorage::~PelStorage()

### DIFF
--- a/source/Lib/CommonLib/Buffer.cpp
+++ b/source/Lib/CommonLib/Buffer.cpp
@@ -638,9 +638,13 @@ PelStorage::~PelStorage()
   {
     destroy();
   }
-  catch( ... )   // this is a destructor, so we don't throw here
+  catch( Exception& e )   // this is a destructor, so we don't throw here
   {
-    msg( ERROR, "PelStorage::~PelStorage: caught exception while releasing the buffers\n" );
+    msg( ERROR, "PelStorage::~PelStorage: caught exception while releasing the buffers: %s\n", e.what() );
+  }
+  catch( ... )
+  {
+    msg( ERROR, "PelStorage::~PelStorage: caught unknown exception while releasing the buffers\n" );
   }
 }
 

--- a/source/Lib/CommonLib/Buffer.cpp
+++ b/source/Lib/CommonLib/Buffer.cpp
@@ -634,7 +634,14 @@ PelStorage::PelStorage()
 
 PelStorage::~PelStorage()
 {
-  destroy();
+  try
+  {
+    destroy();
+  }
+  catch( ... )   // this is a destructor, so we don't throw here
+  {
+    msg( ERROR, "PelStorage::~PelStorage: caught exception while releasing the buffers\n" );
+  }
 }
 
 void PelStorage::create( const UnitArea &_UnitArea )


### PR DESCRIPTION
Found with cppcheck (--enable=all, severity=error) while going over CommonLib:

    source/Lib/CommonLib/Buffer.cpp:637:3: error: Unhandled exception thrown in
    function declared not to throw exceptions. [throwInNoexceptFunction]

PelStorage::~PelStorage() has no exception specification, and none of its bases or
members has a throwing destructor, so it is implicitly noexcept. It calls destroy(),
which has two places that can throw:

  - the CHECK on m_userAlloc->unref, which expands to THROW_RECOVERABLE since
    ALL_CHECKS_ABORT is 0 in every build the CMake setup produces, and
  - the call to m_userAlloc->unref() itself, which is an application supplied
    callback (vvdecUnrefBufferCallback is a plain function pointer with no noexcept
    in the typedef).

Either one leaving the destructor calls std::terminate() and takes the process down,
instead of surfacing through the recoverable exception path the rest of the library
uses.

The CHECK condition itself is not reachable through the public API today.
VVDecImpl::init only sets m_cUserAllocator.enabled when both callbacks are non-null,
and PelStorage::create only records m_userAlloc when the allocator is enabled, so
unref is always valid by the time destroy() runs. The callback throwing is not
covered by anything, though. There is a second way in. PelStorage::destroy() clears
m_origin[i] only after calling unref, and never resets m_externAllocator or
m_userAlloc, so a component that throws keeps all the state that selected the
failing branch. The same PelStorage will take that branch again on the next
destroy().

The realistic way in is picture reuse: PicListManager::getNewPicBuffer calls
pic->destroy() on a recycled DPB picture when an external allocator is in use,
during normal decoding. If the unref callback throws there, VVDecImpl::decode()
converts the recoverable exception to the normal decoder error path, but the
picture stays in m_cPicList with its m_origin pointers intact. At decoder close,
deleteBuffers() calls destroy() on it, catches the throw, and then does
"delete pcPic", which runs ~Picture and ~PelStorage on the same unreleased
component. That second throw is inside a destructor and terminates. So the
try/catch added in #383 stops the first throw but not the one right after it.
This complements #383: deleteBuffers() protects its explicit cleanup call, while
this change protects the subsequent member-destructor cleanup of any PelStorage
whose earlier release left its state intact.

Fix

Wrap the destroy() call in ~PelStorage() in try/catch and log on catch, the same way
PicListManager::deleteBuffers() already does it. destroy() is left as it is, so its
other callers keep getting a catchable exception: a null unref callback with buffers
still to release is an application side API misuse with a leak attached, and the
application is the only party that can fix it. Downgrading that to a log line for
everyone would hide it.

The guard goes in ~PelStorage rather than in the owning classes because PelStorage is
where the freeing happens, and it has several owners (Picture::m_bufs,
Picture::m_subPicRefBufs, CodingStructure::m_reco and m_rec_wrap and m_virtualIBCbuf,
AdaptiveLoopFilter::m_tempBuf, DecLibRecon::m_fltBuf). DecLibRecon::m_fltBuf is worth
calling out: DecLibRecon::destroy() does not release it, so the destructor is its only
release path, and it is one of only two PelStorage objects that can hold externally
allocated memory.

Verification

  - Built Release and Debug, existing unit tests pass.
  - Reference bitstream decode produces bit identical output before and after.
  - Reproduced both throw paths with a small standalone program that fills in a
    UserAllocator by hand (enabled set, unref left null, and a second variant where
    unref throws) and lets a PelStorage go out of scope. Before the change the
    process aborts in the destructor; after it, the error is logged and execution
    continues.

Nothing changes for the normal case: without vvdec_decoder_open_with_allocator the
allocator stays disabled, PelStorage::create takes the xMalloc path, and destroy()
only calls xFree, which cannot throw. The try/catch does not alter normal control
flow when destroy() succeeds.