### PR TITLE
Fix y4m header tagging monochrome frames as 4:2:0

### DIFF
--- a/source/App/vvdecapp/vvdecHelper.h
+++ b/source/App/vvdecapp/vvdecHelper.h
@@ -443,10 +443,13 @@ static int writeY4MHeader( std::ostream *f, vvdecFrame *frame )
 
   if ( frame->sequenceNumber == 0 )
   {
-    const char *cf = (frame->colorFormat == VVDEC_CF_YUV444_PLANAR) ? "444"
+    const bool mono = frame->colorFormat == VVDEC_CF_YUV400_PLANAR;
+
+    const char *cf = mono                                           ? "mono"
+                   : (frame->colorFormat == VVDEC_CF_YUV444_PLANAR) ? "444"
                    : (frame->colorFormat == VVDEC_CF_YUV422_PLANAR) ? "422" : "420";
 
-    const char *bdepth = (frame->bitDepth == 10) ? "p10" : "";
+    const char *bdepth = (frame->bitDepth == 10) ? ( mono ? "10" : "p10" ) : "";
 
     int frameRate=50;
     int frameScale=1;


### PR DESCRIPTION
`define_bitstream_files.cmake` already lists four 4:0:0 conformance streams. Decode one of them with `--y4m` and what comes back stops being readable after the first frame.

The colour tag comes from a three way ternary with no 4:0:0 arm:

    const char *cf = (frame->colorFormat == VVDEC_CF_YUV444_PLANAR) ? "444"
                   : (frame->colorFormat == VVDEC_CF_YUV422_PLANAR) ? "422" : "420";

`VVDEC_CF_YUV400_PLANAR` lands on the fallback, so the header says `C420`. `numPlanes` is 1 for `CHROMA_400` and the writer only emits waht `numPlanes` says, so whatever reads the file takes the next `FRAME` marker for chroma. The payload is fine, it's the header describing it that's wrong.

vvenc's y4m reader already has the case for this - `FileIOHelper.h` uppercases the header line, then maps `CMONO` to 4:0:0 at 8 bit and `CMONO10` at 10. The mono tags don't take the `p` before the depth, which is why the suffix needs a seperate case.

On master, `8b400_A_Bytedance_2` comes out as a file `ffprobe -count_frames` reads 1 frame of 49 from, as `yuv420p`, and ffmpeg quits with `Invalid data found when processing input`. On this branch it's `Cmono`, all 49 come back as `gray`, and ffmpeg is clean. Everything after the header line is byte identical eihter way, and `8b420_A_Bytedance_2` decodes to exactly the same file as before.

Those two lines are unchanged since the y4m writer landed in 2021, so 4:0:0 output has never been right.
