### PR TITLE
Use shared pointers for slice parameter sets

### DIFF
--- a/source/Lib/CommonLib/AdaptiveLoopFilter.cpp
+++ b/source/Lib/CommonLib/AdaptiveLoopFilter.cpp
@@ -627,12 +627,10 @@ void AdaptiveLoopFilter::filterAreaChromaBothCc( const CPelUnitBuf& srcBuf,
   if( filterIdxCb && filterIdxCr )
   {
     const Area blk( Position( 0, 0 ), Size( srcBuf.get( COMPONENT_Cb ) ) );
-    int apsIdxCb = slice->getCcAlfCbApsId();
-    const int16_t* filterCoeffCb =
-        slice->getAlfAPSs()[apsIdxCb]->getCcAlfAPSParam().ccAlfCoeff[COMPONENT_Cb - 1][filterIdxCb - 1];
-    int apsIdxCr = slice->getCcAlfCrApsId();
-    const int16_t* filterCoeffCr =
-        slice->getAlfAPSs()[apsIdxCr]->getCcAlfAPSParam().ccAlfCoeff[COMPONENT_Cr - 1][filterIdxCr - 1];
+    const int      apsIdxCb      = slice->getCcAlfCbApsId();
+    const int16_t* filterCoeffCb = slice->getAlfAPS( apsIdxCb )->getCcAlfAPSParam().ccAlfCoeff[COMPONENT_Cb - 1][filterIdxCb - 1];
+    const int      apsIdxCr      = slice->getCcAlfCrApsId();
+    const int16_t* filterCoeffCr = slice->getAlfAPS( apsIdxCr )->getCcAlfAPSParam().ccAlfCoeff[COMPONENT_Cr - 1][filterIdxCr - 1];
 
     m_filterCcAlfBoth( dstBuf.get( COMPONENT_Cb ), dstBuf.get( COMPONENT_Cr ), srcBuf, blkChroma, blkLuma, filterCoeffCb, filterCoeffCr, clpRngs, m_alfVBLumaCTUHeight, m_alfVBLumaPos );
 
@@ -642,9 +640,8 @@ void AdaptiveLoopFilter::filterAreaChromaBothCc( const CPelUnitBuf& srcBuf,
     if( filterIdxCb )
     {
       const Area blk( Position( 0, 0 ), Size( srcBuf.get( COMPONENT_Cb ) ) );
-      int apsIdx = slice->getCcAlfCbApsId();
-      const int16_t* filterCoeff =
-          slice->getAlfAPSs()[apsIdx]->getCcAlfAPSParam().ccAlfCoeff[COMPONENT_Cb - 1][filterIdxCb - 1];
+      const int      apsIdx      = slice->getCcAlfCbApsId();
+      const int16_t* filterCoeff = slice->getAlfAPS( apsIdx )->getCcAlfAPSParam().ccAlfCoeff[COMPONENT_Cb - 1][filterIdxCb - 1];
 
       m_filterCcAlf( dstBuf.get( COMPONENT_Cb ), srcBuf, blkChroma, blkLuma, COMPONENT_Cb, filterCoeff, clpRngs, m_alfVBLumaCTUHeight, m_alfVBLumaPos );
     }
@@ -652,9 +649,8 @@ void AdaptiveLoopFilter::filterAreaChromaBothCc( const CPelUnitBuf& srcBuf,
     if( filterIdxCr )
     {
       const Area blk( Position( 0, 0 ), Size( srcBuf.get( COMPONENT_Cr ) ) );
-      int apsIdx = slice->getCcAlfCrApsId();
-      const int16_t* filterCoeff =
-          slice->getAlfAPSs()[apsIdx]->getCcAlfAPSParam().ccAlfCoeff[COMPONENT_Cr - 1][filterIdxCr - 1];
+      const int      apsIdx      = slice->getCcAlfCrApsId();
+      const int16_t* filterCoeff = slice->getAlfAPS( apsIdx )->getCcAlfAPSParam().ccAlfCoeff[COMPONENT_Cr - 1][filterIdxCr - 1];
 
       m_filterCcAlf( dstBuf.get( COMPONENT_Cr ), srcBuf, blkChroma, blkLuma, COMPONENT_Cr, filterCoeff, clpRngs, m_alfVBLumaCTUHeight, m_alfVBLumaPos );
     }
@@ -671,9 +667,14 @@ void AdaptiveLoopFilter::filterCTU( const CPelUnitBuf&     srcBuf,
                                     Position               ctuPos,
                                     int                    tid )
 {
-  const Slice*         slice          = cs.getCtuData( ctuIdx ).cuPtr[0][0]->slice;
-  const APS* const*    aps            = slice->getAlfAPSs();
-  const PreCalcValues& pcv            = *cs.pcv;
+  const Slice*         slice                     = cs.getCtuData( ctuIdx ).cuPtr[0][0]->slice;
+  const APS*           apss[ALF_CTB_MAX_NUM_APS] = { 0 };
+  const PreCalcValues& pcv                       = *cs.pcv;
+
+  for( int i = 0; i < ALF_CTB_MAX_NUM_APS; i++ )
+  {
+    apss[i] = slice->getAlfAPS( i );
+  }
 
   bool clipTop = false, clipBottom = false, clipLeft = false, clipRight = false;
   int  numHorVirBndry   = 0;
@@ -722,23 +723,23 @@ void AdaptiveLoopFilter::filterCTU( const CPelUnitBuf&     srcBuf,
       {
         const Area blk( Position( 0, 0 ), Size( srcBuf.get( compID ) ) );
         const short filterSetIndex = ctuAlfData.alfCtbFilterIndex;
-        filterAreaLuma( srcBuf, dstBuf, blk, slice, aps, filterSetIndex, clpRngs, tid );
+        filterAreaLuma( srcBuf, dstBuf, blk, slice, apss, filterSetIndex, clpRngs, tid );
       }
       else
       {
         const Area blkLuma  ( Position( 0, 0 ), Size( width, height ) );
         const Area blkChroma( Position( 0, 0 ), Size( srcBuf.get( compID ) ) );
 
-        filterAreaChroma( srcBuf, dstBuf, blkChroma, compID, slice, aps, ctuAlfData, clpRngs );
+        filterAreaChroma( srcBuf, dstBuf, blkChroma, compID, slice, apss, ctuAlfData, clpRngs );
       }
     }
-    
+
     // has chroma
     if( numComp > 1 )
     {
-      const Area blkLuma  ( Position( 0, 0 ), Size( width, height ) );
+      const Area blkLuma( Position( 0, 0 ), Size( width, height ) );
       const Area blkChroma( Position( 0, 0 ), Size( srcBuf.get( COMPONENT_Cb ) ) );
-      filterAreaChromaBothCc( srcBuf, dstBuf, blkLuma, blkChroma, slice, aps, ctuAlfData, clpRngs );
+      filterAreaChromaBothCc( srcBuf, dstBuf, blkLuma, blkChroma, slice, apss, ctuAlfData, clpRngs );
     }
   }
   else
@@ -833,15 +834,15 @@ void AdaptiveLoopFilter::filterCTU( const CPelUnitBuf&     srcBuf,
             {
               const Area blk( xInSrc, yInSrc, w, h );
               const short filterSetIndex = ctuAlfData.alfCtbFilterIndex;
-              filterAreaLuma( m_tempBuf[tid], dstBuf, blk, slice, aps, filterSetIndex, clpRngs, tid );
+              filterAreaLuma( m_tempBuf[tid], dstBuf, blk, slice, apss, filterSetIndex, clpRngs, tid );
             }
             else
             {
               const Area blkLuma ( Position( xInSrc,                 yInSrc ),                 Size( w,                 h ) );
               const Area blkChoma( Position( xInSrc >> chromaScaleX, yInSrc >> chromaScaleY ), Size( w >> chromaScaleX, h >> chromaScaleY ) );
 
-              filterAreaChroma( m_tempBuf[tid], dstBuf, blkChoma, compID, slice, aps, ctuAlfData, clpRngs );
-              filterAreaChromaCc( m_tempBuf[tid], dstBuf, blkLuma, blkChoma, compID, slice, aps, ctuAlfData, clpRngs );
+              filterAreaChroma( m_tempBuf[tid], dstBuf, blkChoma, compID, slice, apss, ctuAlfData, clpRngs );
+              filterAreaChromaCc( m_tempBuf[tid], dstBuf, blkLuma, blkChoma, compID, slice, apss, ctuAlfData, clpRngs );
             }
             xStart = xEnd;
           }
@@ -855,7 +856,6 @@ void AdaptiveLoopFilter::filterCTU( const CPelUnitBuf&     srcBuf,
 void AdaptiveLoopFilter::reconstructCoeffAPSs( Slice& slice )
 {
   const SPS*  sps = slice.getSPS();
-  const APS** aps = slice.getAlfAPSs();
 
   // luma
   if( slice.getAlfEnabledFlag( COMPONENT_Y ) )
@@ -863,7 +863,7 @@ void AdaptiveLoopFilter::reconstructCoeffAPSs( Slice& slice )
     for( int i = 0; i < slice.getNumAlfAps(); i++ )
     {
       int        apsIdx = slice.getAlfApsIdsLuma()[i];
-      const APS* curAPS = aps[apsIdx];
+      const APS* curAPS = slice.getAlfAPS( apsIdx );
       CHECK( curAPS == NULL, "invalid APS" );
 
       AlfSliceParam& alfSliceParamTmp = curAPS->getMutableAlfAPSParam();
@@ -876,7 +876,7 @@ void AdaptiveLoopFilter::reconstructCoeffAPSs( Slice& slice )
   if( slice.getAlfEnabledFlag( COMPONENT_Cb ) || slice.getAlfEnabledFlag( COMPONENT_Cr ) )
   {
     int        apsIdxChroma = slice.getAlfApsIdChroma();
-    const APS* curAPS       = aps[apsIdxChroma];
+    const APS* curAPS       = slice.getAlfAPS( apsIdxChroma );
     CHECK( curAPS == NULL, "invalid APS" );
 
     AlfSliceParam& alfSliceParamTmp = curAPS->getMutableAlfAPSParam();

--- a/source/Lib/CommonLib/Slice.cpp
+++ b/source/Lib/CommonLib/Slice.cpp
@@ -275,7 +275,7 @@ Slice::Slice()
   resetWpScaling();
   initWpAcDcParam();
 
-  memset( m_alfApss, 0, sizeof( m_alfApss ) );
+  clearAlfAPSs();
 }
 
 

--- a/source/Lib/CommonLib/Slice.h
+++ b/source/Lib/CommonLib/Slice.h
@@ -1643,7 +1643,7 @@ public:
   bool                    getEntryPointsPresentFlag() const                                               { return m_entryPointPresentFlag;                                      }
   void                    setEntryPointsPresentFlag(bool val)                                             { m_entryPointPresentFlag = val;                                       }
 
-  static constexpr int    getMaxLog2TrDynamicRange( ChannelType )            			                        { return 15; }
+  static constexpr int    getMaxLog2TrDynamicRange( ChannelType )                                         { return 15; }
 
   int                     getQpBDOffset() const                                                           { return m_qpBDOffset;                                                 }
   void                    setQpBDOffset(int i)                                                            { m_qpBDOffset = i;                                                    }
@@ -2541,9 +2541,9 @@ private:
   std::pair<int, int>        m_scalingRatio       [NUM_REF_PIC_LIST_01][MAX_NUM_REF_PICS];
 
   // access channel
-  const VPS*                 m_pcVPS                         = nullptr;
-  const SPS*                 m_pcSPS                         = nullptr;
-  const PPS*                 m_pcPPS                         = nullptr;
+  std::shared_ptr<const VPS> m_pcVPS                         = nullptr;
+  std::shared_ptr<const SPS> m_pcSPS                         = nullptr;
+  std::shared_ptr<const PPS> m_pcPPS                         = nullptr;
   Picture*                   m_pcPic                         = nullptr;
   PicHeader*                 m_pcPicHeader                   = nullptr;    //!< pointer to picture header structure
   bool                       m_colFromL0Flag                 = true;   // collocated picture from List0 flag
@@ -2584,15 +2584,15 @@ public:
   PicHeader*                  getPicHeader() const                                   { return m_pcPicHeader;                                         }
   int                         getRefIdx4MVPair( RefPicList eCurRefPicList, int nCurRefIdx );
 
-  void                        setVPS( const VPS* pcVPS )                             { m_pcVPS = pcVPS;                                              }
-  const VPS*                  getVPS() const                                         { CHECK_NULLPTR( m_pcVPS ); return m_pcVPS;                     }
-  const VPS*                  getVPS_nothrow() const                                 { return m_pcVPS;                                               }
+  void                        setVPS( const VPS* pcVPS )                             { m_pcVPS.reset( pcVPS );                                       }
+  const VPS*                  getVPS() const                                         { CHECK_NULLPTR( m_pcVPS ); return m_pcVPS.get();               }
+  const VPS*                  getVPS_nothrow() const                                 { return m_pcVPS.get();                                         }
 
-  void                        setSPS( const SPS* pcSPS )                             { m_pcSPS = pcSPS;                                              }
-  const SPS*                  getSPS() const                                         { CHECK_NULLPTR( m_pcSPS ); return m_pcSPS;                     }
+  void                        setSPS( const SPS* pcSPS )                             { m_pcSPS.reset( pcSPS );                                       }
+  const SPS*                  getSPS() const                                         { CHECK_NULLPTR( m_pcSPS ); return m_pcSPS.get();               }
 
-  void                        setPPS( const PPS* pcPPS )                             { m_pcPPS = pcPPS;                                              }
-  const PPS*                  getPPS() const                                         { CHECK_NULLPTR( m_pcPPS ); return m_pcPPS;                     }
+  void                        setPPS( const PPS* pcPPS )                             { m_pcPPS.reset( pcPPS );                                       }
+  const PPS*                  getPPS() const                                         { CHECK_NULLPTR( m_pcPPS ); return m_pcPPS.get();               }
 
   void                        setAlfApss( std::shared_ptr<const APS> apss[ALF_CTB_MAX_NUM_APS] ) { for( int i = 0; i < ALF_CTB_MAX_NUM_APS; ++i ) { m_alfApss[i] = apss[i]; } }
   void                        setAlfApss(                 const APS *apss[ALF_CTB_MAX_NUM_APS] ) { for( int i = 0; i < ALF_CTB_MAX_NUM_APS; ++i ) { m_alfApss[i] = apss[i] ? apss[i]->getSharedPtr() : nullptr; } }

--- a/source/Lib/CommonLib/Slice.h
+++ b/source/Lib/CommonLib/Slice.h
@@ -2567,7 +2567,7 @@ private:
 
   uint32_t                   m_sliceSubPicId                 = 0;
 
-  const APS*                 m_alfApss[ALF_CTB_MAX_NUM_APS]      = { 0 };
+  std::shared_ptr<const APS> m_alfApss[ALF_CTB_MAX_NUM_APS];
   bool                       m_alfEnabledFlag[MAX_NUM_COMPONENT] = { false, false, false };
   int                        m_numAlfAps                         = 0;
   AlfApsIdVec                m_lumaAlfApsId;
@@ -2594,11 +2594,10 @@ public:
   void                        setPPS( const PPS* pcPPS )                             { m_pcPPS = pcPPS;                                              }
   const PPS*                  getPPS() const                                         { CHECK_NULLPTR( m_pcPPS ); return m_pcPPS;                     }
 
-  void                        setAlfApss( std::shared_ptr<const APS> apss[ALF_CTB_MAX_NUM_APS] ) { for( int i = 0; i < ALF_CTB_MAX_NUM_APS; ++i ) { m_alfApss[i] = apss[i].get(); } }
-  void                        setAlfApss(                 const APS *apss[ALF_CTB_MAX_NUM_APS] ) { for( int i = 0; i < ALF_CTB_MAX_NUM_APS; ++i ) { m_alfApss[i] = apss[i]; } }
-  void                        clearAlfAPSs()                                         { memset( m_alfApss, 0, sizeof( m_alfApss ) );                  }
-  const APS**                 getAlfAPSs()                                           { return m_alfApss;                                             }
-  const APS* const*           getAlfAPSs() const                                     { return m_alfApss;                                             }
+  void                        setAlfApss( std::shared_ptr<const APS> apss[ALF_CTB_MAX_NUM_APS] ) { for( int i = 0; i < ALF_CTB_MAX_NUM_APS; ++i ) { m_alfApss[i] = apss[i]; } }
+  void                        setAlfApss(                 const APS *apss[ALF_CTB_MAX_NUM_APS] ) { for( int i = 0; i < ALF_CTB_MAX_NUM_APS; ++i ) { m_alfApss[i] = apss[i] ? apss[i]->getSharedPtr() : nullptr; } }
+  void                        clearAlfAPSs()                                         { for( int i = 0; i < ALF_CTB_MAX_NUM_APS; ++i ) { m_alfApss[i].reset(); } }
+  const APS*                  getAlfAPS( int idx ) const                             { return m_alfApss[idx].get();                                  }
   void                        setSaoEnabledFlag(ChannelType chType, bool s)          { m_saoEnabledFlag[chType] = s;                                 }
   bool                        getSaoEnabledFlag(ChannelType chType) const            { return m_saoEnabledFlag[chType];                              }
   void                        clearRPL( RefPicList l )                               { m_RPL[l].clear();                                             }

--- a/source/Lib/DecoderLib/CABACReader.cpp
+++ b/source/Lib/DecoderLib/CABACReader.cpp
@@ -425,8 +425,8 @@ void CABACReader::readAlf( CodingStructure& cs, unsigned int ctuRsAddr, const Pa
         if( isChroma( ( ComponentID ) compIdx ) )
         {
           const int apsIdx                  = m_slice->getAlfApsIdChroma();
-          CHECK( m_slice->getAlfAPSs()[apsIdx] == nullptr, "APS not initialized" );
-          const AlfSliceParam& alfParam     = m_slice->getAlfAPSs()[apsIdx]->getAlfAPSParam();
+          CHECK( m_slice->getAlfAPS( apsIdx ) == nullptr, "APS not initialized" );
+          const AlfSliceParam& alfParam     = m_slice->getAlfAPS( apsIdx )->getAlfAPSParam();
           const int numAlts                 = alfParam.numAlternativesChroma;
           currAlfData.alfCtuAlternative[compIdx - 1] = 0;
 
@@ -455,7 +455,7 @@ void CABACReader::readAlf( CodingStructure& cs, unsigned int ctuRsAddr, const Pa
       if ( idcVal )
       {
         const int apsIdx        = compIdx == 1 ? m_slice->getCcAlfCbApsId() : m_slice->getCcAlfCrApsId();
-        const int filterCount   = m_slice->getAlfAPSs()[apsIdx]->getCcAlfAPSParam().ccAlfFilterCount[compIdx - 1];
+        const int filterCount   = m_slice->getAlfAPS( apsIdx )->getCcAlfAPSParam().ccAlfFilterCount[compIdx - 1];
         while ( ( idcVal != filterCount ) && m_BinDecoder.decodeBinEP() )
         {
           idcVal++;


### PR DESCRIPTION
The parameter sets (especially the ALF APSs) could be destroyed, while still in use by a slice, when a new parameter set with the same ID was parsed. Using smart pointers in the Slice class ensures the actual PSs are still accessible, while the slice is still in use.

fixes #390 #391 #392